### PR TITLE
Add backend documentation index

### DIFF
--- a/MicroM/Documentation/Backend/index.md
+++ b/MicroM/Documentation/Backend/index.md
@@ -1,0 +1,48 @@
+# Backend Namespaces
+
+The backend of MicroM is organized into several namespaces. Each namespace groups related functionality and has its own dedicated documentation.
+
+## Configuration
+Handles application and database configuration options.
+[Documentation](./Configuration/)
+
+## Core
+Provides base classes for entities, actions, and initialization helpers.
+[Documentation](./Core/)
+
+## Data
+Implements the data layer for CRUD operations, filtering, and lookups.
+[Documentation](./Data/)
+
+## DataDictionary
+Defines metadata for entities, menus, and security configuration.
+[Documentation](./DataDictionary/)
+
+## Database
+Tools for creating, updating, and managing the database schema.
+[Documentation](./Database/)
+
+## Excel
+Utilities for working with Excel exports.
+[Documentation](./Excel/)
+
+## Extensions
+Common extension methods used throughout the framework.
+[Documentation](./Extensions/)
+
+## Generators
+Code and SQL generation for backend and frontend components.
+[Documentation](./Generators/)
+
+## ImportData
+Services for parsing and importing data from external sources.
+[Documentation](./ImportData/)
+
+## Validators
+Validation helpers for entities and input data.
+[Documentation](./Validators/)
+
+## Web
+Web API controllers, services, and authentication utilities.
+[Documentation](./Web/)
+


### PR DESCRIPTION
## Summary
- add documentation index for MicroM backend namespaces

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689fbfe668188324a182cd86b86c349d