### PR TITLE
Add DataDictionary documentation

### DIFF
--- a/MicroM/Documentation/Backend/DataDictionary/CategoriesDefinitions/AuthenticationTypes.md
+++ b/MicroM/Documentation/Backend/DataDictionary/CategoriesDefinitions/AuthenticationTypes.md
@@ -1,0 +1,8 @@
+# AuthenticationTypes
+
+Represents the authentication mechanism used by an application.
+
+Values:
+
+- **SQLServerAuthentication** – authenticates using a SQL Server login.
+- **MicroMAuthentication** – authenticates using MicroM credentials.

--- a/MicroM/Documentation/Backend/DataDictionary/CategoriesDefinitions/IdentityProviderRole.md
+++ b/MicroM/Documentation/Backend/DataDictionary/CategoriesDefinitions/IdentityProviderRole.md
@@ -1,0 +1,9 @@
+# IdentityProviderRole
+
+Defines the role played by an application with respect to an identity provider.
+
+Values:
+
+- **IDPDisabled** – local identity provider, no external integration.
+- **IDPClient** – acts as a client of a remote identity provider.
+- **IDPServer** – provides identity services to other applications.

--- a/MicroM/Documentation/Backend/DataDictionary/CategoriesDefinitions/UserTypes.md
+++ b/MicroM/Documentation/Backend/DataDictionary/CategoriesDefinitions/UserTypes.md
@@ -1,0 +1,8 @@
+# UserTypes
+
+Available user types within MicroM.
+
+Values:
+
+- **ADMIN** – system administrator.
+- **USER** – regular user.

--- a/MicroM/Documentation/Backend/DataDictionary/CategoriesDefinitions/index.md
+++ b/MicroM/Documentation/Backend/DataDictionary/CategoriesDefinitions/index.md
@@ -1,0 +1,7 @@
+# Category Definitions
+
+Category definitions map friendly names to identifiers used in category fields.
+
+- [AuthenticationTypes](AuthenticationTypes.md)
+- [IdentityProviderRole](IdentityProviderRole.md)
+- [UserTypes](UserTypes.md)

--- a/MicroM/Documentation/Backend/DataDictionary/Configuration/index.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Configuration/index.md
@@ -1,0 +1,27 @@
+# Configuration Namespace
+
+Classes in `MicroM.DataDictionary.Configuration` provide reusable building blocks used by entities and categories.
+
+## CategoryDefinition
+Base type for defining categories. Each specific category derives from this class and exposes `CategoryValuesDefinition` instances.
+
+## CategoryValuesDefinition
+Represents a single value inside a category.
+
+## StatusDefinition
+Abstract base class for status enumerations.
+
+## StatusValuesDefinition
+Defines a specific status value.
+
+## IDDescriptionDefinition
+Helper structure containing an identifier and descriptive text.
+
+## MenuDefinition & MenuItemDefinition
+Describe application menus and the routes each menu item allows.
+
+## UsersGroupDefinition
+Describes a security group and its allowed routes.
+
+## TableSuffix
+Static helper that exposes common table name suffixes.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/Applications/Applications.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/Applications/Applications.md
@@ -1,0 +1,34 @@
+# Applications
+
+Stores configuration for each MicroM application.
+
+## Columns
+- `c_application_id` (PK)
+- `vc_appname`
+- `vc_appurls` – array of frontend URLs (fake)
+- `vc_apiurl`
+- `vc_server`
+- `vc_user`
+- `vc_password` – encrypted
+- `vc_database`
+- `vc_app_admin_user`
+- `vc_app_admin_password` – encrypted
+- `vc_JWTIssuer`
+- `vc_JWTAudience`
+- `vc_JWTKey`
+- `i_JWTTokenExpirationMinutes`
+- `i_JWTRefreshExpirationHours`
+- `i_AccountLockoutMinutes`
+- `i_MaxBadLogonAttempts`
+- `i_MaxRefreshTokenAttempts`
+- `c_authenticationtype_id` – category [`AuthenticationTypes`](../../CategoriesDefinitions/AuthenticationTypes.md)
+- `vc_assembly1` … `vc_assembly5` – embedded assemblies (fake)
+- `b_createdatabase`, `b_dropdatabase`, `b_adminuserhasrights`, `b_appdbexists`, `b_appuserexists`, `b_serverup` – action/status flags (fake)
+- `c_identity_provider_role_id` – category [`IdentityProviderRole`](../../CategoriesDefinitions/IdentityProviderRole.md)
+- `vc_oidc_url_wellknown`, `vc_oidc_url_jwks`, `vc_oidc_url_authorize`, `vc_oidc_url_token_backchannel`, `vc_oidc_url_endsession`
+
+## Relationships
+- Category links to `AuthenticationTypes` and `IdentityProviderRole`.
+
+## Typical Usage
+Represents the core configuration for an application including database credentials, JWT settings and optional OpenID Connect endpoints. Used when creating or updating application records and bootstrapping databases.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/Applications/ApplicationsCat.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/Applications/ApplicationsCat.md
@@ -1,0 +1,15 @@
+# ApplicationsCat
+
+Associates applications with category values.
+
+## Columns
+- `c_application_id` (PK, FK to `Applications`)
+- `c_category_id` (PK)
+- `c_categoryvalue_id` (FK to `CategoriesValues`)
+
+## Relationships
+- `FKApplicationsCat` – links to the parent `Applications` record.
+- `FKCategories` – links to `CategoriesValues`.
+
+## Typical Usage
+Used to tag applications with additional category information.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/Applications/index.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/Applications/index.md
@@ -1,0 +1,4 @@
+# Applications Entities
+
+- [Applications](Applications.md)
+- [ApplicationsCat](ApplicationsCat.md)

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/EmailService/EmailServiceConfiguration.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/EmailService/EmailServiceConfiguration.md
@@ -1,0 +1,18 @@
+# EmailServiceConfiguration
+
+SMTP settings used by the email service.
+
+## Columns
+- `c_email_configuration_id` (PK)
+- `vc_smtp_host`
+- `i_smtp_port`
+- `vc_user_name`
+- `vc_password` – encrypted
+- `bt_use_ssl`
+- `vc_default_sender_email`
+- `vc_default_sender_name`
+- `vc_template_subject` (fake)
+- `vc_template_body` (fake)
+
+## Typical Usage
+Holds SMTP credentials and default sender information for outbound email.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/EmailService/EmailServiceQueue.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/EmailService/EmailServiceQueue.md
@@ -1,0 +1,27 @@
+# EmailServiceQueue
+
+Queue of emails awaiting delivery.
+
+## Columns
+- `c_email_queue_id` (PK)
+- `c_email_configuration_id` (FK to `EmailServiceConfiguration`)
+- `vc_external_reference`
+- `c_email_process_id`
+- `vc_sender_email`
+- `vc_sender_name`
+- `vc_destination_email`
+- `vc_destination_name`
+- `vc_subject`
+- `vc_message`
+- `vc_last_error`
+- `i_retries`
+- `c_emailstatus_id` – status identifier
+- `vc_json_destination_and_tags` (fake)
+- `c_email_template_id` (FK, fake)
+
+## Relationships
+- `FKConfiguration` – links to `EmailServiceConfiguration`.
+- Indexes on process identifiers.
+
+## Typical Usage
+Emails are inserted here and later processed by the email worker. Procedures support queuing messages and templates.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/EmailService/EmailServiceQueueStatus.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/EmailService/EmailServiceQueueStatus.md
@@ -1,0 +1,14 @@
+# EmailServiceQueueStatus
+
+Tracks status values applied to queued emails.
+
+## Columns
+- `c_email_queue_id` (PK, FK to `EmailServiceQueue`)
+- `c_status_id` (PK)
+- `c_statusvalue_id` (FK to `StatusValues`)
+
+## Relationships
+- `FKQueue` – links to `EmailServiceQueue`.
+
+## Typical Usage
+Provides historical status information for items in the email queue.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/EmailService/EmailServiceTemplates.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/EmailService/EmailServiceTemplates.md
@@ -1,0 +1,11 @@
+# EmailServiceTemplates
+
+Reusable email templates.
+
+## Columns
+- `c_email_template_id` (PK)
+- `vc_template_subject`
+- `vc_template_body`
+
+## Typical Usage
+Stores subjects and bodies that can be referenced when queuing emails.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/EmailService/index.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/EmailService/index.md
@@ -1,0 +1,6 @@
+# Email Service Entities
+
+- [EmailServiceConfiguration](EmailServiceConfiguration.md)
+- [EmailServiceTemplates](EmailServiceTemplates.md)
+- [EmailServiceQueue](EmailServiceQueue.md)
+- [EmailServiceQueueStatus](EmailServiceQueueStatus.md)

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/FileStore/FileStore.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/FileStore/FileStore.md
@@ -1,0 +1,19 @@
+# FileStore
+
+Metadata for a single stored file.
+
+## Columns
+- `c_file_id` (PK)
+- `c_fileprocess_id` (FK to `FileStoreProcess`)
+- `vc_filename`
+- `vc_filefolder`
+- `vc_fileguid`
+- `bi_filesize`
+- `c_fileuploadstatus_id` – status identifier
+
+## Relationships
+- `FKFileStoreProcess` – links to `FileStoreProcess`.
+- `UCFileStore` unique constraint on `vc_fileguid`.
+
+## Typical Usage
+Tracks files on disk and their upload status. Procedure `fst_getByGUID` fetches metadata using the GUID.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/FileStore/FileStoreProcess.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/FileStore/FileStoreProcess.md
@@ -1,0 +1,9 @@
+# FileStoreProcess
+
+Represents a file upload/download operation.
+
+## Columns
+- `c_fileprocess_id` (PK)
+
+## Typical Usage
+Used as a parent record for files stored in the system.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/FileStore/FileStoreStatus.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/FileStore/FileStoreStatus.md
@@ -1,0 +1,15 @@
+# FileStoreStatus
+
+Associates status values with stored files.
+
+## Columns
+- `c_file_id` (PK, FK to `FileStore`)
+- `c_status_id` (PK)
+- `c_statusvalue_id` (FK to `StatusValues`)
+
+## Relationships
+- `FKFileStoreStatus` – links to `FileStore`.
+- `FKStatus` – links to `StatusValues`.
+
+## Typical Usage
+Used to track the lifecycle of a file (uploaded, processed, etc.).

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/FileStore/index.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/FileStore/index.md
@@ -1,0 +1,5 @@
+# File Store Entities
+
+- [FileStoreProcess](FileStoreProcess.md)
+- [FileStore](FileStore.md)
+- [FileStoreStatus](FileStoreStatus.md)

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsers.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsers.md
@@ -1,0 +1,28 @@
+# MicromUsers
+
+Represents users within MicroM.
+
+## Columns
+- `c_user_id` (PK)
+- `vc_username`
+- `vc_email`
+- `vc_pwhash`
+- `vb_sid`
+- `i_badlogonattempts`
+- `bt_disabled`
+- `dt_locked`
+- `dt_last_login`
+- `dt_last_refresh`
+- `vc_recovery_code`
+- `dt_last_recovery`
+- `c_usertype_id` – category [`UserTypes`](../../CategoriesDefinitions/UserTypes.md)
+- `vc_user_groups` – list of groups (fake)
+- `bt_islocked`, `i_locked_minutes_remaining` – lock status (fake)
+- `vc_password` – plain text placeholder (fake)
+
+## Relationships
+- `UNUsername` unique constraint on `vc_username`.
+- `FKGroups` (fake) links to [MicromUsersGroups](MicromUsersGroups.md).
+
+## Typical Usage
+Stores credential and status information for each user. Contains helper procedures for login attempts, password resets and claim retrieval.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsersCat.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsersCat.md
@@ -1,0 +1,15 @@
+# MicromUsersCat
+
+Associates users with category values.
+
+## Columns
+- `c_user_id` (PK, FK to `MicromUsers`)
+- `c_category_id` (PK)
+- `c_categoryvalue_id` (FK to `CategoriesValues`)
+
+## Relationships
+- `FKMicromUsers` – links to `MicromUsers`.
+- `FKCategories` – links to `CategoriesValues`.
+
+## Typical Usage
+Used to tag users with category metadata such as roles or custom flags.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsersDevices.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsersDevices.md
@@ -1,0 +1,18 @@
+# MicromUsersDevices
+
+Tracks devices used by users for authentication.
+
+## Columns
+- `c_user_id` (PK, FK to `MicromUsers`)
+- `c_device_id` (PK)
+- `vc_useragent`
+- `vc_ipaddress`
+- `vc_refreshtoken`
+- `dt_refresh_expiration`
+- `i_refreshcount`
+
+## Relationships
+- `FKMicromUsers` – links to `MicromUsers`.
+
+## Typical Usage
+Stores refresh tokens and metadata per device. Includes procedure `usd_refreshToken` to rotate tokens.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsersGroups.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsersGroups.md
@@ -1,0 +1,15 @@
+# MicromUsersGroups
+
+Defines security groups for users.
+
+## Columns
+- `c_user_group_id` (PK)
+- `vc_user_group_name`
+- `vc_group_members` – list of member identifiers (fake)
+
+## Relationships
+- `UNGroupName` unique constraint on `vc_user_group_name`.
+- `FKUsers` (fake) links to [MicromUsers](MicromUsers.md).
+
+## Typical Usage
+Groups are used to assign permissions and menu access to multiple users.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsersGroupsMembers.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsersGroupsMembers.md
@@ -1,0 +1,14 @@
+# MicromUsersGroupsMembers
+
+Many‑to‑many association between users and groups.
+
+## Columns
+- `c_user_group_id` (PK, FK to `MicromUsersGroups`)
+- `c_user_id` (PK, FK to `MicromUsers`)
+
+## Relationships
+- `FKMicromUsers` – links to `MicromUsers`.
+- `FKGroups` – links to `MicromUsersGroups`.
+
+## Typical Usage
+Defines membership of users inside groups.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsersGroupsMenus.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsersGroupsMenus.md
@@ -1,0 +1,15 @@
+# MicromUsersGroupsMenus
+
+Associates groups with menu items they may access.
+
+## Columns
+- `c_user_group_id` (PK, FK to `MicromUsersGroups`)
+- `c_menu_id` (PK)
+- `c_menu_item_id` (PK)
+
+## Relationships
+- `FKGroups` – links to `MicromUsersGroups`.
+- `FKMenus` – links to `MicromMenusItems`.
+
+## Typical Usage
+Controls which menu items are available to members of a group.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsersLoginHistory.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsersLoginHistory.md
@@ -1,0 +1,14 @@
+# MicromUsersLoginHistory
+
+Audit table storing login attempts.
+
+## Columns
+- `c_user_history_id` (PK)
+- `c_user_id` (PK, FK to `MicromUsers`)
+- `vc_useragent`
+- `vc_ipaddress`
+- `bt_success`
+- `dt_login_attempt`
+
+## Typical Usage
+Used to record successful or failed login attempts for monitoring and security analysis.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsersStatusPanelDef.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/MicromUsersStatusPanelDef.md
@@ -1,0 +1,18 @@
+# MicromUsersStatusPanelDef
+
+Reusable definition that extends other entities with user‑creation fields.
+
+## Columns
+- `vc_username`
+- `vc_password`
+- `vc_user_groups` – array of groups
+- `bt_disabled`
+- `bt_islocked`
+- `i_badlogonattempts`
+- `i_locked_minutes_remaining`
+- `dt_locked`
+- `dt_last_login`
+- `dt_last_refresh`
+
+## Typical Usage
+Embed this definition into other entities that need to create or update users, such as administrative screens.

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/index.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/MicromUsers/index.md
@@ -1,0 +1,10 @@
+# Microm Users Entities
+
+- [MicromUsers](MicromUsers.md)
+- [MicromUsersCat](MicromUsersCat.md)
+- [MicromUsersGroups](MicromUsersGroups.md)
+- [MicromUsersGroupsMembers](MicromUsersGroupsMembers.md)
+- [MicromUsersGroupsMenus](MicromUsersGroupsMenus.md)
+- [MicromUsersDevices](MicromUsersDevices.md)
+- [MicromUsersLoginHistory](MicromUsersLoginHistory.md)
+- [MicromUsersStatusPanelDef](MicromUsersStatusPanelDef.md)

--- a/MicroM/Documentation/Backend/DataDictionary/Entities/index.md
+++ b/MicroM/Documentation/Backend/DataDictionary/Entities/index.md
@@ -1,0 +1,8 @@
+# Entities
+
+Entities represent database tables and their accompanying logic. They are grouped into functional areas:
+
+- [Applications](Applications/index.md)
+- [Microm Users](MicromUsers/index.md)
+- [Email Service](EmailService/index.md)
+- [File Store](FileStore/index.md)

--- a/MicroM/Documentation/Backend/DataDictionary/index.md
+++ b/MicroM/Documentation/Backend/DataDictionary/index.md
@@ -1,0 +1,7 @@
+# Data Dictionary
+
+This section documents the core backend data structures used by **MicroM**. It is split into:
+
+- [Configuration](Configuration/index.md) – reusable definitions for categories, status values and menus.
+- [Entities](Entities/index.md) – database entities grouped by functional area.
+- [Category Definitions](CategoriesDefinitions/index.md) – enumerations backing category fields.


### PR DESCRIPTION
## Summary
- document Data Dictionary structure, configuration, and categories
- add entity references for applications, users, email service, and file store

## Testing
- `dotnet test MicroM.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689fbff79d1c8324a6a3f0ab38f52452