### PR TITLE
docs: add generator documentation

### DIFF
--- a/MicroM/Documentation/Backend/Generators/Extensions/index.md
+++ b/MicroM/Documentation/Backend/Generators/Extensions/index.md
@@ -1,0 +1,15 @@
+# Generator Extensions
+
+Common helper methods used across generators live under `MicroM.core.Generators.Extensions`.
+
+## Text Utilities
+
+- `RemoveEmptyLines` – Collapses multiple blank lines to a single line using `GeneratorsRegex.MultipleEmptyLines`.
+- `AddSpacesAndLowercaseShortWords` – Splits camel‑case identifiers into words and lowercases short words for friendlier titles.
+
+## Template Helpers
+
+- `ReplaceTemplate` – Replaces tokens in a template using values from a `TemplateValuesBase` instance.
+
+These methods keep generated files readable and free of repetitive boilerplate.
+

--- a/MicroM/Documentation/Backend/Generators/ReactGenerator/index.md
+++ b/MicroM/Documentation/Backend/Generators/ReactGenerator/index.md
@@ -1,0 +1,19 @@
+# React Generator
+
+The React generator transforms backend entities into TypeScript classes and forms that consume the MicroM client library.
+
+## Workflow
+
+1. Each entity builds a `TemplateValues` object describing class names, columns, views, lookups, and procedures.
+2. Templates in `Templates.cs` describe the structure of category classes, entity definitions, entities, and forms.
+3. Extension methods assemble token values and clean up the output using helpers from the shared `Extensions` namespace.
+
+## Key Extension Methods
+
+- `EntityExtensions.AsTypeScriptEntityDefinition` – builds the `{Entity}Def` class with columns, views, lookups, and procedures.
+- `EntityExtensions.AsTypeScriptEntity` – creates the runtime entity wrapper that loads forms and icons.
+- `EntityExtensions.AsTypeScriptEntityForm` – generates a default form with field controls.
+- `CategoriesExtensions.AsTypeScriptCategories` and `LookupExtensions.AsLookupDefinition` provide category and lookup snippets used by the entity templates.
+
+Together these pieces create a ready‑to‑use React client that matches the backend schema.
+

--- a/MicroM/Documentation/Backend/Generators/SQLGenerator/index.md
+++ b/MicroM/Documentation/Backend/Generators/SQLGenerator/index.md
@@ -1,0 +1,19 @@
+# SQL Generator
+
+The SQL generator creates scripts for tables, views, and CRUD stored procedures based on entity definitions.
+
+## Workflow
+
+1. Build a `TemplateValues` instance with table names, columns, and parameters.
+2. Apply tokens to the templates defined in `Templates.cs` (e.g. `VIEW_TEMPLATE`, `DROP_TEMPLATE`).
+3. Use helpers in the `Extensions` namespace to post‑process the result.
+
+## Key Extension Methods
+
+- `TableExtensions.AsCreateTable` – produces `CREATE TABLE` and index scripts.
+- `TableExtensions.IsTableCreated` – checks whether an entity's table already exists.
+- `ColumnExtensions.AsSQLTypeString` – converts column metadata to SQL type declarations.
+- `ColumnExtensions.ToSQLName` – converts PascalCase names to snake_case SQL identifiers.
+
+These methods, together with the templates, automate generation of consistent SQL Server artifacts.
+

--- a/MicroM/Documentation/Backend/Generators/index.md
+++ b/MicroM/Documentation/Backend/Generators/index.md
@@ -1,0 +1,16 @@
+# Generators
+
+MicroM includes a flexible code generation system for both SQL and React code.  Generators use templates combined with extension methods to transform entity definitions into ready-to-use artifacts.  This section provides an overview of the workflow and links to detailed documentation for individual generators and extension helpers.
+
+## Workflow
+
+1. **Template values** – Each generator fills a `TemplateValuesBase` derived object with tokens such as entity names, columns, or view definitions.
+2. **Template replacement** – The raw template strings are stored in `Templates.cs` files.  Tokens are replaced using `TemplateExtensions.ReplaceTemplate`.
+3. **Post processing** – Text helpers in `Generators.Extensions.CommonExtensions` clean up the generated code by trimming extra blank lines or formatting identifiers.
+
+## Contents
+
+- [Extensions](./Extensions/index.md) – Helpers shared by generators.
+- [SQL Generator](./SQLGenerator/index.md) – Creates database schema, procedures, and related SQL.
+- [React Generator](./ReactGenerator/index.md) – Produces React entities, forms, and supporting files.
+


### PR DESCRIPTION
## Summary
- add generator overview with workflow and references to extensions, SQL, and React generators
- document text and template helper extensions
- describe SQL and React generator templates and key extension methods

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689fbffbe8088324b88d76b516562fbc