### PR TITLE
docs: describe Excel reader and export

### DIFF
--- a/MicroM/Documentation/Backend/Excel/index.md
+++ b/MicroM/Documentation/Backend/Excel/index.md
@@ -1,0 +1,35 @@
+# Excel
+
+MicroM provides utilities for working with Excel (`.xlsx`) spreadsheets via the [`MicroM.Excel`](../../..//core/Excel) namespace.
+
+## Reading spreadsheets
+
+`ExcelReader` reads a worksheet stream asynchronously and yields each row as an array of values. The first row is treated as the header and subsequent rows contain typed values based on the cell's data type.
+
+```csharp
+await using var stream = File.OpenRead("data.xlsx");
+
+await foreach (var row in ExcelReader.ReadExcelAsync(stream, "Sheet1"))
+{
+    // row[0], row[1], ...
+}
+```
+
+The reader inspects each cell and converts numbers, booleans and dates to `double`, `bool` and `DateTime` respectively. If a cell contains a shared string or is empty, the corresponding element remains a `string` or `null`.
+
+## Writing `DataResult` to Excel
+
+`DataResult` represents tabular results in MicroM. The `SaveAsExcelToStreamAsync` extension creates an Excel file from a `DataResult` instance:
+
+```csharp
+var data = new DataResult(
+    new[] { "Header1", "Header2" },
+    new[] { "string", "double" });
+
+data.records.Add(new object?[] { "Value1", 123.45 });
+
+using var stream = new MemoryStream();
+await data.SaveAsExcelToStreamAsync(stream, "Sheet1");
+```
+
+The extension writes the headers and records to a worksheet, handling null, numeric, boolean and date values appropriately. The resulting workbook can later be parsed using `ExcelReader`.


### PR DESCRIPTION
## Summary
- document ExcelReader usage for reading Excel files
- document DataResult SaveAsExcelToStreamAsync for exporting results

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689fbffea4d88324ad2c4df458258594