### PR TITLE
docs: add backend validator regex documentation

### DIFF
--- a/MicroM/Documentation/Backend/Validators/index.md
+++ b/MicroM/Documentation/Backend/Validators/index.md
@@ -1,0 +1,19 @@
+# Validators
+
+This section documents the regular expressions used by MicroM's backend validators and the scenarios they cover.
+
+## URL Validator
+
+- **Regex:** `^https?://[^\s]+[^\s]$` *(case-insensitive)*
+- **Scenario:** Ensures a value is an HTTP or HTTPS URL without spaces.
+
+## Phone Validator
+
+- **Regex:** `^\+?\d+$`
+- **Scenario:** Validates phone numbers consisting of digits with an optional leading `+`.
+
+## Email Validator
+
+- **Regex:** `/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/`
+- **Scenario:** Confirms a value follows a standard email address format.
+


### PR DESCRIPTION
## Summary
- document regex patterns for backend URL, phone, and email validators

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689fc000ae7483248b6cf90ec8e6eab6