### PR TITLE
docs: fix configuration xrefs

### DIFF
--- a/MicroM/Documentation/Backend/Configuration/index.md
+++ b/MicroM/Documentation/Backend/Configuration/index.md
@@ -3,49 +3,31 @@
 Provides options and defaults for the MicroM framework. These settings control database connections, security, and application behavior.
 
 ## Related Types
-- `ApplicationOption`
-- `ConfigurationDefaults`
-- `DataDefaults`
-- `IDatabaseSchema`
-- `IPublicEndpoints`
-- `MicroMOptions`
-- `SecretsOptions`
+- [`ApplicationOption`](../../core/Configuration/ApplicationOption.cs)
+- [`ConfigurationDefaults`](../../core/Configuration/ConfigurationDefaults.cs)
+- [`DataDefaults`](../../core/Configuration/DataDefaults.cs)
+- [`IDatabaseSchema`](../../core/Configuration/IDatabaseSchema.cs)
+- [`IPublicEndpoints`](../../core/Configuration/IPublicEndpoints.cs)
+- [`MicroMOptions`](../../core/Configuration/MicroMOptions.cs)
+- [`SecretsOptions`](../../core/Configuration/SecretsOptions.cs)
 
 ## ApplicationOption
-<xref:MicroM.Configuration.ApplicationOption>
-
-Defines application-specific settings such as database connections, JWT parameters, and allowed frontend origins.
+`ApplicationOption` defines application-specific settings such as database connections, JWT parameters, and allowed frontend origins【F:core/Configuration/ApplicationOption.cs†L8-L40】.
 
 ## ConfigurationDefaults
-<xref:MicroM.Configuration.ConfigurationDefaults>
-
-Constants used when generating configuration files, including default database names, certificate details, and upload settings.
+`ConfigurationDefaults` provides constants used when generating configuration files, including default database names, certificate details, and upload settings【F:core/Configuration/ConfigurationDefaults.cs†L6-L38】.
 
 ## DataDefaults
-<xref:MicroM.Configuration.DataDefaults>
-
-Defines defaults for data access operations like timeouts and row limits.
+`DataDefaults` defines defaults for data access operations like timeouts and row limits【F:core/Configuration/DataDefaults.cs†L3-L38】.
 
 ## IDatabaseSchema
-<xref:MicroM.Configuration.IDatabaseSchema>
-
-Interface for creating and migrating the MicroM database schema.
+`IDatabaseSchema` is an interface for creating and migrating the MicroM database schema【F:core/Configuration/IDatabaseSchema.cs†L20-L37】.
 
 ## IPublicEndpoints
-<xref:MicroM.Configuration.IPublicEndpoints>
-
-Declares routes that should be exposed without authentication.
+`IPublicEndpoints` declares routes that should be exposed without authentication【F:core/Configuration/IPublicEndpoints.cs†L3-L13】.
 
 ## MicroMOptions
-<xref:MicroM.Configuration.MicroMOptions>
-
-Common configuration values:
-
-- `DefaultConnectionTimeOutInSecs` – default SQL connection timeout.
-- `DefaultCommandTimeOutInMins` – default command timeout.
-- `UploadsFolder` – path for uploaded files.
+`MicroMOptions` holds common configuration values such as default timeouts and upload settings【F:core/Configuration/MicroMOptions.cs†L3-L33】.
 
 ## SecretsOptions
-<xref:MicroM.Configuration.SecretsOptions>
-
-Stores database credentials securely.
+`SecretsOptions` stores database credentials securely【F:core/Configuration/SecretsOptions.cs†L3-L13】.


### PR DESCRIPTION
## Summary
- replace unresolved xrefs in backend configuration docs with direct links to source files

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: del: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a50118790c83249f2d3ccdb6e1dba8