### PR TITLE
docs: remove empty template sections from MicroM.Configuration docs

### DIFF
--- a/MicroM/Documentation-Progress/Backend/docs-state-backend.md
+++ b/MicroM/Documentation-Progress/Backend/docs-state-backend.md
@@ -6,7 +6,7 @@ This file tracks the current documentation state of the backend (/MicroM/core).
 
 ### MicroM.Configuration
 - State: Complete ✅
-- Notes: Namespace index and type docs present.
+- Notes: Namespace index and type docs present; class docs aligned with templates.
 
 ### MicroM.Core
 - State: Complete ✅

--- a/MicroM/Documentation-Progress/Backend/iteration-summary.md
+++ b/MicroM/Documentation-Progress/Backend/iteration-summary.md
@@ -74,3 +74,34 @@
 
 ### Forward Tasks
 - Document MicroM.DataDictionary.CategoriesDefinitions namespace.
+
+## Iteration 5 – Template Alignment
+### Plan
+- Review MicroM.Configuration markdown files for template compliance, adding missing **Inheritance** and **Implements** sections.
+
+### Execution Results
+- Success: Updated ApplicationOption.md, ConfigurationDefaults.md, DataDefaults.md, MicroMOptions.md, and SecretsOptions.md.
+
+### Verification Results
+- Success: Confirmed all updated files include required sections and match class documentation template.
+
+### Issues Encountered
+- None.
+
+### Forward Tasks
+- Audit remaining namespaces for missing template sections.
+## Iteration 6 – Template Cleanup
+### Plan
+- Remove empty template sections from MicroM.Configuration documentation.
+
+### Execution Results
+- Success: stripped unused Inheritance, Implements, Constructors, Methods, and Structs sections from MicroM.Configuration markdown files and index.
+
+### Verification Results
+- Success: confirmed MicroM.Configuration pages contain only applicable template sections.
+
+### Issues Encountered
+- None.
+
+### Forward Tasks
+- Continue auditing remaining namespaces for template compliance.

--- a/MicroM/Documentation/Backend/MicroM.Configuration/ApplicationOption.md
+++ b/MicroM/Documentation/Backend/MicroM.Configuration/ApplicationOption.md
@@ -30,11 +30,6 @@ Configuration settings for a MicroM application including database and authentic
 | IdentityProviderClients | List<string> | Valid identity provider client identifiers. |
 | FrontendURLS | List<string> | Allowed frontend URLs for cross-origin requests. |
 
-## Methods
-| Method | Description |
-|:------------|:-------------|
-| *(none)* | |
-
 ## Remarks
 Use this to map application configuration from appsettings files.
 

--- a/MicroM/Documentation/Backend/MicroM.Configuration/ConfigurationDefaults.md
+++ b/MicroM/Documentation/Backend/MicroM.Configuration/ConfigurationDefaults.md
@@ -3,11 +3,6 @@
 ## Overview
 Default configuration values used when no explicit settings are provided.
 
-## Constructors
-| Constructor | Description |
-|:------------|:-------------|
-| *(none)* | Not instantiable.
-
 ## Properties
 | Property | Type | Description |
 |:------------|:-------------|:-------------|
@@ -20,11 +15,6 @@ Default configuration values used when no explicit settings are provided.
 | SecretsFilePath | string | Path where the secrets file is stored. |
 | UploadsFolder | string | Folder name for uploaded files. |
 | AllowedFileUploadExtensions | string[] | Allowed file extensions for uploads. |
-
-## Methods
-| Method | Description |
-|:------------|:-------------|
-| *(none)* | |
 
 ## Remarks
 Provides defaults used across MicroM when configuration values are absent.

--- a/MicroM/Documentation/Backend/MicroM.Configuration/DataDefaults.md
+++ b/MicroM/Documentation/Backend/MicroM.Configuration/DataDefaults.md
@@ -3,11 +3,6 @@
 ## Overview
 Default values for data access operations.
 
-## Constructors
-| Constructor | Description |
-|:------------|:-------------|
-| *(none)* | Not instantiable.
-
 ## Properties
 | Property | Type | Description |
 |:------------|:-------------|:-------------|
@@ -19,11 +14,6 @@ Default values for data access operations.
 | AppendDBOtoProcs | bool | Indicates to append "dbo." to a stored procedure if owner is not specified. |
 | DefaultRowLimitForViews | int | Default limit for returned rows from a view. |
 | RowLimitParameterName | string | Parameter name for row_limit in views. |
-
-## Methods
-| Method | Description |
-|:------------|:-------------|
-| *(none)* | |
 
 ## Remarks
 These defaults influence data access behavior across MicroM.

--- a/MicroM/Documentation/Backend/MicroM.Configuration/MicroMOptions.md
+++ b/MicroM/Documentation/Backend/MicroM.Configuration/MicroMOptions.md
@@ -23,11 +23,6 @@ Options for configuring core MicroM behaviors and defaults.
 | MicroMAPICookieRootPath | string? | Cookie root path for the MicroM API. |
 | DefaultSQLDatabaseCollation | string? | Default SQL collation for new databases. |
 
-## Methods
-| Method | Description |
-|:------------|:-------------|
-| *(none)* | |
-
 ## Remarks
 Defines common options that influence runtime behavior of MicroM components.
 

--- a/MicroM/Documentation/Backend/MicroM.Configuration/SecretsOptions.md
+++ b/MicroM/Documentation/Backend/MicroM.Configuration/SecretsOptions.md
@@ -14,11 +14,6 @@ Options for storing sensitive configuration values such as database credentials.
 | ConfigSQLUser | string? | SQL user for the configuration database. |
 | ConfigSQLPassword | string? | Password for the configuration database user. |
 
-## Methods
-| Method | Description |
-|:------------|:-------------|
-| *(none)* | |
-
 ## Remarks
 Use external storage to protect secrets in production environments.
 

--- a/MicroM/Documentation/Backend/MicroM.Configuration/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Configuration/index.md
@@ -17,11 +17,6 @@ Provides core configuration abstractions and defaults for MicroM.
 |:------------|:-------------|
 | [DatabaseMigrationResult](DatabaseMigrationResult.md) | Result values for database migration operations. |
 
-## Structs
-| Struct | Description |
-|:------------|:-------------|
-| *(none)* | |
-
 ## Interfaces
 | Interface | Description |
 |:------------|:-------------|


### PR DESCRIPTION
## Summary
- drop unused Inheritance, Implements, Methods, Constructors, and Structs sections from MicroM.Configuration docs
- record template cleanup in iteration summary

## Testing
- `dotnet test MicroM.sln` *(fails: `/usr/bin/sh: 2: ... del: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f68e4d2483249ff12dcd12baf7bd