### PR TITLE
docs: expand backend documentation iteration 8

### DIFF
--- a/MicroM/Documentation-Progress/Backend/docs-state-backend.md
+++ b/MicroM/Documentation-Progress/Backend/docs-state-backend.md
@@ -20,7 +20,7 @@ This file tracks the current documentation state of the backend (`/MicroM/core`)
 
 ### MicroM.DataDictionary
 - State: Incomplete ⚠️
-- Notes: Namespace index and initial types documented; remaining types require documentation.
+- Notes: Namespace index updated; application assembly and OIDC classes documented; remaining types require documentation.
 
 ### MicroM.DataDictionary.CategoriesDefinitions
 - State: Complete ✅
@@ -32,11 +32,11 @@ This file tracks the current documentation state of the backend (`/MicroM/core`)
 
 ### MicroM.DataDictionary.Entities
 - State: Incomplete ⚠️
-- Notes: ConfigurationParameters documented; remaining entities pending.
+- Notes: ConfigurationParameters documented; MicromUsers partially documented (LoginResult, LoginAttemptResult, LoginAttemptStatus, LoginData, RefreshTokenResult); remaining entities pending.
 
 ### MicroM.DataDictionary.Entities.MicromUsers
-- State: Not Started ❌
-- Notes: No documentation present.
+- State: Incomplete ⚠️
+- Notes: Namespace index with LoginResult, LoginAttemptResult, LoginAttemptStatus, LoginData, and RefreshTokenResult documented.
 
 ### MicroM.DataDictionary.StatusDefs
 - State: Not Started ❌

--- a/MicroM/Documentation-Progress/Backend/iteration-summary.md
+++ b/MicroM/Documentation-Progress/Backend/iteration-summary.md
@@ -58,7 +58,7 @@
 
 ---
 
-## Iteration 2
+## Iteration 6
 ### Plan
 - Add XML comments for selected `MicroM.Core` types:
   - `MicroM/core/Core/CRC32.cs`
@@ -207,3 +207,57 @@
 ### Next iteration Tasks
 - Document remaining classes in `MicroM.DataDictionary.Entities`.
 - Begin documenting `MicroM.DataDictionary.Entities.MicromUsers` namespace.
+
+## Iteration 7
+### Plan
+- Document additional `MicroM.DataDictionary` classes:
+  - Add XML comments to `MicroM/core/DataDictionary/Entities/ApplicationAssemblyTypes/ApplicationAssemblyTypes.cs` and create docs under `MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationAssemblyTypes*`.
+  - Add XML comments to `MicroM/core/DataDictionary/Entities/ApplicationOIDCClients/ApplicationOidcClients.cs` and create docs under `MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationOidcClients*`.
+  - Add XML comments to `MicroM/core/DataDictionary/Entities/ApplicationOIDCServer/ApplicationOidcServer.cs` and create docs under `MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationOidcServer*`.
+- Begin documenting `MicroM.DataDictionary.Entities.MicromUsers` namespace:
+  - Add XML comments to `LoginResult`, `LoginAttemptResult`, and `LoginAttemptStatus` classes in `MicroM/core/DataDictionary/Entities/MicromUsers/`.
+  - Create namespace and type docs under `MicroM/Documentation/Backend/MicroM.DataDictionary.Entities.MicromUsers/`.
+- Update root documentation index and `docs-state-backend.md` for new coverage.
+### Execution Results
+- Added XML comments and documentation for ApplicationAssemblyTypes classes → ✅ Success
+- Added XML comments and documentation for ApplicationOidcClients classes → ✅ Success
+- Added XML comments and documentation for ApplicationOidcServer classes → ✅ Success
+- Created MicromUsers namespace docs with LoginResult, LoginAttemptResult, and LoginAttemptStatus → ✅ Success
+- Updated root index and documentation state → ✅ Success
+
+### Verification Results
+- Verified XML comments in updated source files → ✅ Success
+- Confirmed new markdown files follow templates and are linked from indexes → ✅ Success
+- `docs-state-backend.md` entries updated for relevant namespaces → ✅ Success
+
+### Issues Encountered
+- Remaining classes in `MicroM.DataDictionary` and `MicromUsers` namespaces lack documentation.
+
+### Next iteration Tasks
+- Continue documenting remaining `MicroM.DataDictionary` classes.
+- Expand `MicroM.DataDictionary.Entities.MicromUsers` documentation with additional types.
+
+## Iteration 8
+### Plan
+- Add XML comments for additional MicromUsers record types:
+  - `MicroM/core/DataDictionary/Entities/MicromUsers/LoginData.cs`
+  - `MicroM/core/DataDictionary/Entities/MicromUsers/RefreshResult.cs`
+- Create documentation pages for these classes under `MicroM/Documentation/Backend/MicroM.DataDictionary.Entities.MicromUsers/`.
+- Update namespace index and `docs-state-backend.md` for new coverage.
+
+### Execution Results
+- Added XML comments to `LoginData` and `RefreshTokenResult` records → ✅ Success
+- Created documentation pages for `LoginData` and `RefreshTokenResult` → ✅ Success
+- Updated MicromUsers namespace index and progress files → ✅ Success
+
+### Verification Results
+- Verified XML comments in updated source files → ✅ Success
+- Confirmed markdown files follow templates and are linked from indexes → ✅ Success
+- `docs-state-backend.md` shows additional MicromUsers coverage → ✅ Success
+
+### Issues Encountered
+- Other MicromUsers and DataDictionary classes remain undocumented.
+
+### Next iteration Tasks
+- Document remaining MicromUsers classes (e.g., `MicromUsers`, `MicromUsersDevices`).
+- Continue expanding `MicroM.DataDictionary` entities documentation.

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities.MicromUsers/LoginAttemptResult/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities.MicromUsers/LoginAttemptResult/index.md
@@ -1,0 +1,21 @@
+# Class: MicroM.DataDictionary.Entities.MicromUsers.LoginAttemptResult
+## Overview
+Represents the result of a login attempt including status and optional tokens.
+
+**Inheritance**
+object -> LoginAttemptResult
+
+## Example Usage
+```csharp
+var attempt = new MicroM.DataDictionary.Entities.MicromUsers.LoginAttemptResult();
+```
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| Status | LoginAttemptStatus | Status of the login attempt. |
+| Message | string? | Optional message describing the result. |
+| RefreshToken | string? | Refresh token issued when the attempt succeeds. |
+
+## See Also
+- [LoginAttemptStatus](../LoginAttemptStatus/index.md)
+- [LoginResult](../LoginResult/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities.MicromUsers/LoginAttemptStatus/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities.MicromUsers/LoginAttemptStatus/index.md
@@ -1,0 +1,21 @@
+# Enum: MicroM.DataDictionary.Entities.MicromUsers.LoginAttemptStatus
+## Overview
+Outcome codes for login attempts.
+
+## Members
+| Member | Description |
+|:------------|:-------------|
+| Updated | Login state updated successfully. |
+| InvalidRefreshToken | Provided refresh token is invalid. |
+| RefreshTokenExpired | Refresh token has expired. |
+| MaxRefreshReached | Maximum number of refresh attempts reached. |
+| UserIDNotFound | User identifier not found. |
+| AccountLocked | Account is locked. |
+| AccountDisabled | Account is disabled. |
+| RefreshTokenValid | Refresh token is valid. |
+| LoggedInOK | Login succeeded. |
+| Unknown | Unknown result. |
+
+## See Also
+- [LoginAttemptResult](../LoginAttemptResult/index.md)
+- [LoginResult](../LoginResult/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities.MicromUsers/LoginData/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities.MicromUsers/LoginData/index.md
@@ -1,0 +1,32 @@
+# Class: MicroM.DataDictionary.Entities.MicromUsers.LoginData
+## Overview
+Represents authentication and status information retrieved for a user.
+
+**Inheritance**
+object -> LoginData
+
+## Example Usage
+```csharp
+var data = new MicroM.DataDictionary.Entities.MicromUsers.LoginData();
+```
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| user_id | string | Unique identifier of the user. |
+| locked | bool | Indicates whether the account is locked. |
+| pwhash | string | Hash of the user's password. |
+| badlogonattempts | int | Number of failed login attempts. |
+| locked_minutes_remaining | int | Minutes remaining before lockout expires. |
+| email | string? | Email address associated with the account. |
+| username | string | Username for the account. |
+| disabled | bool | Indicates whether the account is disabled. |
+| refresh_token | string? | Refresh token issued to the user. |
+| refresh_expired | bool | Indicates if the refresh token has expired. |
+| usertype_id | string? | Identifier of the user type. |
+| usertype_name | string? | Name of the user type. |
+| user_groups | string? | JSON array string of groups the user belongs to. |
+
+## See Also
+- [LoginAttemptResult](../LoginAttemptResult/index.md)
+- [RefreshTokenResult](../RefreshTokenResult/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities.MicromUsers/LoginResult/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities.MicromUsers/LoginResult/index.md
@@ -1,0 +1,23 @@
+# Class: MicroM.DataDictionary.Entities.MicromUsers.LoginResult
+## Overview
+Represents the response returned after a successful login.
+
+**Inheritance**
+object -> LoginResult
+
+## Example Usage
+```csharp
+var result = new MicroM.DataDictionary.Entities.MicromUsers.LoginResult();
+```
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| email | string? | Email associated with the user. |
+| username | string | Username of the authenticated user. |
+| refresh_token | string? | Refresh token issued for the session. |
+| client_claims | Dictionary&lt;string, string&gt; | Client-specific claims. |
+| authenticator_result | AuthenticatorResult | Result of the authenticator challenge. |
+
+## See Also
+- [LoginAttemptResult](../LoginAttemptResult/index.md)
+- [LoginAttemptStatus](../LoginAttemptStatus/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities.MicromUsers/RefreshTokenResult/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities.MicromUsers/RefreshTokenResult/index.md
@@ -1,0 +1,23 @@
+# Class: MicroM.DataDictionary.Entities.MicromUsers.RefreshTokenResult
+## Overview
+Result of a refresh token request.
+
+**Inheritance**
+object -> RefreshTokenResult
+
+## Example Usage
+```csharp
+var result = new MicroM.DataDictionary.Entities.MicromUsers.RefreshTokenResult();
+```
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| Status | LoginAttemptStatus | Outcome of the refresh attempt. |
+| Message | string? | Optional message describing the result. |
+| RefreshToken | string? | Newly issued refresh token. |
+| RefreshExpiration | DateTime? | Expiration time for the refresh token. |
+
+## See Also
+- [LoginAttemptStatus](../LoginAttemptStatus/index.md)
+- [LoginAttemptResult](../LoginAttemptResult/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities.MicromUsers/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities.MicromUsers/index.md
@@ -1,0 +1,32 @@
+# Namespace: MicroM.DataDictionary.Entities.MicromUsers
+## Overview
+Types related to MicroM user authentication and status tracking.
+
+## Classes
+| Class | Description |
+|:------------|:-------------|
+| [LoginAttemptResult](LoginAttemptResult/index.md) | Result of a login attempt. |
+| [LoginData](LoginData/index.md) | Retrieved authentication and status data for a user. |
+| [LoginResult](LoginResult/index.md) | Response returned after a successful login. |
+| [RefreshTokenResult](RefreshTokenResult/index.md) | Result of a refresh token request. |
+
+## Enums
+| Enum | Description |
+|:------------|:-------------|
+| [LoginAttemptStatus](LoginAttemptStatus/index.md) | Outcome codes for login attempts. |
+
+## Structs
+| Struct | Description |
+|:------------|:-------------|
+| - | - |
+
+## Interfaces
+| Interface | Description |
+|:------------|:-------------|
+| - | - |
+
+## Remarks
+Additional MicromUsers types remain undocumented.
+
+## See Also
+- [MicroM.DataDictionary.Entities](../MicroM.DataDictionary.Entities/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/index.md
@@ -25,3 +25,4 @@ Additional entities exist in this namespace and will be documented in future ite
 
 ## See Also
 - [MicroM.DataDictionary](../MicroM.DataDictionary/index.md)
+- [MicroM.DataDictionary.Entities.MicromUsers](../MicroM.DataDictionary.Entities.MicromUsers/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationAssemblyTypes/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationAssemblyTypes/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.DataDictionary.ApplicationAssemblyTypes
+## Overview
+Runtime entity for interacting with application assembly type records.
+
+**Inheritance**
+Entity<ApplicationAssemblyTypesDef> -> ApplicationAssemblyTypes
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ApplicationAssemblyTypes() | Initializes a new instance. |
+| ApplicationAssemblyTypes(IEntityClient ec, IMicroMEncryption? encryptor = null) | Initializes with a database client and optional encryptor. |
+
+## See Also
+- [ApplicationAssemblyTypesDef](../ApplicationAssemblyTypesDef/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationAssemblyTypesDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationAssemblyTypesDef/index.md
@@ -1,0 +1,24 @@
+# Class: MicroM.DataDictionary.ApplicationAssemblyTypesDef
+## Overview
+Definition for application assembly type records.
+
+**Inheritance**
+EntityDefinition -> ApplicationAssemblyTypesDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ApplicationAssemblyTypesDef() | Initializes the definition with default metadata. |
+
+## Fields
+| Field | Type | Description |
+|:------------|:-------------|:-------------|
+| c_application_id | Column&lt;string&gt; | Application identifier. |
+| c_assembly_id | Column&lt;string&gt; | Assembly identifier. |
+| i_order | Column&lt;int&gt; | Display order of the assembly type. |
+| c_assemblytype_id | Column&lt;string&gt; | Assembly type identifier. |
+| apt_brwStandard | ViewDefinition | Standard browse view definition. |
+| APTGetCode | APTGetCode | Procedure helper to retrieve assembly type code. |
+
+## See Also
+- [ApplicationAssemblyTypes](../ApplicationAssemblyTypes/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationOidcClients/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationOidcClients/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.DataDictionary.ApplicationOidcClients
+## Overview
+Runtime entity for managing OIDC client registrations.
+
+**Inheritance**
+Entity<ApplicationOidcClientsDef> -> ApplicationOidcClients
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ApplicationOidcClients() | Initializes a new instance. |
+| ApplicationOidcClients(IEntityClient ec, IMicroMEncryption? encryptor = null) | Initializes with a database client and optional encryptor. |
+
+## See Also
+- [ApplicationOidcClientsDef](../ApplicationOidcClientsDef/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationOidcClientsDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationOidcClientsDef/index.md
@@ -1,0 +1,27 @@
+# Class: MicroM.DataDictionary.ApplicationOidcClientsDef
+## Overview
+Definition for OpenID Connect client application records.
+
+**Inheritance**
+EntityDefinition -> ApplicationOidcClientsDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ApplicationOidcClientsDef() | Initializes the definition. |
+
+## Fields
+| Field | Type | Description |
+|:------------|:-------------|:-------------|
+| c_application_id | Column&lt;string&gt; | Application identifier. |
+| c_client_app_id | Column&lt;string&gt; | Client application identifier. |
+| c_user_id | Column&lt;string&gt; | User identifier associated with the client. |
+| vc_url_sso_root | Column&lt;string&gt; | Root URL for the SSO client. |
+| vc_url_sso_login | Column&lt;string&gt; | Login URL for the SSO client. |
+| vc_url_sso_backchannel_logout | Column&lt;string&gt; | Back-channel logout URL. |
+| vc_url_sso_logged_out | Column&lt;string&gt; | Redirect URL after logout. |
+| FKApplicationsClients | EntityForeignKey&lt;Applications, ApplicationOidcClients&gt; | Link to parent application. |
+| FKApplicationClientsUser | EntityForeignKey&lt;MicromUsers, ApplicationOidcClients&gt; | Link to owning user. |
+
+## See Also
+- [ApplicationOidcClients](../ApplicationOidcClients/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationOidcServer/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationOidcServer/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.DataDictionary.ApplicationOidcServer
+## Overview
+Runtime entity for managing OIDC server configuration.
+
+**Inheritance**
+Entity<ApplicationOidcServerDef> -> ApplicationOidcServer
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ApplicationOidcServer() | Initializes a new instance. |
+| ApplicationOidcServer(IEntityClient ec, IMicroMEncryption? encryptor = null) | Initializes with a database client and optional encryptor. |
+
+## See Also
+- [ApplicationOidcServerDef](../ApplicationOidcServerDef/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationOidcServerDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationOidcServerDef/index.md
@@ -1,0 +1,25 @@
+# Class: MicroM.DataDictionary.ApplicationOidcServerDef
+## Overview
+Definition for OIDC server configuration records.
+
+**Inheritance**
+EntityDefinition -> ApplicationOidcServerDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ApplicationOidcServerDef() | Initializes the definition. |
+
+## Fields
+| Field | Type | Description |
+|:------------|:-------------|:-------------|
+| c_application_id | Column&lt;string&gt; | Application identifier. |
+| vc_url_wellknown | Column&lt;string?&gt; | Well-known configuration URL. |
+| vc_url_jwks | Column&lt;string?&gt; | JWKS endpoint URL. |
+| vc_url_authorize | Column&lt;string?&gt; | Authorization endpoint URL. |
+| vc_url_token_backchannel | Column&lt;string?&gt; | Back-channel token endpoint URL. |
+| vc_url_endsession | Column&lt;string?&gt; | End session endpoint URL. |
+| FKApplicationsClients | EntityForeignKey&lt;Applications, ApplicationOidcServer&gt; | Link to parent application. |
+
+## See Also
+- [ApplicationOidcServer](../ApplicationOidcServer/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/index.md
@@ -5,6 +5,12 @@ Data dictionary entity definitions and related helpers.
 ## Classes
 | Class | Description |
 |:------------|:-------------|
+| [ApplicationAssemblyTypesDef](ApplicationAssemblyTypesDef/index.md) | Schema definition for application assembly types. |
+| [ApplicationAssemblyTypes](ApplicationAssemblyTypes/index.md) | Entity for application assembly types. |
+| [ApplicationOidcClientsDef](ApplicationOidcClientsDef/index.md) | Schema definition for OIDC client applications. |
+| [ApplicationOidcClients](ApplicationOidcClients/index.md) | Entity for OIDC client applications. |
+| [ApplicationOidcServerDef](ApplicationOidcServerDef/index.md) | Schema definition for OIDC server configuration. |
+| [ApplicationOidcServer](ApplicationOidcServer/index.md) | Entity for OIDC server configuration. |
 | [CategoriesDef](CategoriesDef/index.md) | Schema definition for categories. |
 | [Categories](Categories/index.md) | Entity for working with categories. |
 | [CategoriesValuesDef](CategoriesValuesDef/index.md) | Schema definition for category values. |

--- a/MicroM/Documentation/Backend/index.md
+++ b/MicroM/Documentation/Backend/index.md
@@ -12,7 +12,7 @@ This section provides documentation for the MicroM backend namespaces.
 | [MicroM.DataDictionary.CategoriesDefinitions](MicroM.DataDictionary.CategoriesDefinitions/index.md) | Category definitions for common MicroM lookup values. |
 | [MicroM.DataDictionary.Configuration](MicroM.DataDictionary.Configuration/index.md) | Configuration helpers and definitions for categories, statuses, menus and groups. |
 | [MicroM.DataDictionary.Entities](MicroM.DataDictionary.Entities/index.md) | Data dictionary entities like configuration parameters. |
-| MicroM.DataDictionary.Entities.MicromUsers | Documentation not started. |
+| [MicroM.DataDictionary.Entities.MicromUsers](MicroM.DataDictionary.Entities.MicromUsers/index.md) | Authentication-related entity helpers and results. |
 | MicroM.DataDictionary.StatusDefs | Documentation not started. |
 | MicroM.Database | Documentation not started. |
 | MicroM.Excel | Documentation not started. |

--- a/MicroM/core/DataDictionary/Entities/ApplicationAssemblyTypes/ApplicationAssemblyTypes.cs
+++ b/MicroM/core/DataDictionary/Entities/ApplicationAssemblyTypes/ApplicationAssemblyTypes.cs
@@ -4,23 +4,62 @@ using MicroM.Web.Services;
 
 namespace MicroM.DataDictionary
 {
+    /// <summary>
+    /// Schema definition for application assembly types.
+    /// </summary>
     public class ApplicationAssemblyTypesDef : EntityDefinition
     {
-        public ApplicationAssemblyTypesDef() : base("apt",nameof(ApplicationAssemblyTypes)) { Fake = true; }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationAssemblyTypesDef"/> class.
+        /// </summary>
+        public ApplicationAssemblyTypesDef() : base("apt", nameof(ApplicationAssemblyTypes)) { Fake = true; }
 
+        /// <summary>
+        /// Application identifier.
+        /// </summary>
         public readonly Column<string> c_application_id = Column<string>.PK();
+
+        /// <summary>
+        /// Assembly identifier.
+        /// </summary>
         public readonly Column<string> c_assembly_id = Column<string>.PK();
+
+        /// <summary>
+        /// Display order of the assembly type.
+        /// </summary>
         public readonly Column<int> i_order = new(column_flags: ColumnFlags.PK);
+
+        /// <summary>
+        /// Assembly type identifier.
+        /// </summary>
         public readonly Column<string> c_assemblytype_id = Column<string>.PK();
 
+        /// <summary>
+        /// Default view for browsing application assembly types.
+        /// </summary>
         public ViewDefinition apt_brwStandard { get; private set; } = new(nameof(c_application_id), nameof(c_assembly_id), nameof(i_order), nameof(c_assemblytype_id));
 
+        /// <summary>
+        /// Procedure helper for retrieving assembly type code.
+        /// </summary>
         public APTGetCode APTGetCode { get; private set; } = new();
     }
 
+    /// <summary>
+    /// Entity for managing application assembly types.
+    /// </summary>
     public class ApplicationAssemblyTypes : Entity<ApplicationAssemblyTypesDef>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationAssemblyTypes"/> class.
+        /// </summary>
         public ApplicationAssemblyTypes() : base() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationAssemblyTypes"/> class with the specified client and encryption provider.
+        /// </summary>
+        /// <param name="ec">Entity client used for data access.</param>
+        /// <param name="encryptor">Optional encryption provider.</param>
         public ApplicationAssemblyTypes(IEntityClient ec, IMicroMEncryption? encryptor = null) : base(ec, encryptor) { }
 
 

--- a/MicroM/core/DataDictionary/Entities/ApplicationOIDCClients/ApplicationOidcClients.cs
+++ b/MicroM/core/DataDictionary/Entities/ApplicationOIDCClients/ApplicationOidcClients.cs
@@ -4,27 +4,78 @@ using MicroM.Web.Services;
 
 namespace MicroM.DataDictionary;
 
+/// <summary>
+/// Schema definition for OIDC client applications associated with a MicroM application.
+/// </summary>
 public class ApplicationOidcClientsDef : EntityDefinition
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationOidcClientsDef"/> class.
+    /// </summary>
     public ApplicationOidcClientsDef() : base("aoic", nameof(ApplicationOidcClients)) { }
 
+    /// <summary>
+    /// Application identifier.
+    /// </summary>
     public readonly Column<string> c_application_id = Column<string>.PK();
+
+    /// <summary>
+    /// Client application identifier.
+    /// </summary>
     public readonly Column<string> c_client_app_id = Column<string>.PK();
+
+    /// <summary>
+    /// User identifier associated with the client.
+    /// </summary>
     public readonly Column<string> c_user_id = Column<string>.FK();
 
+    /// <summary>
+    /// Root URL for the SSO client.
+    /// </summary>
     public readonly Column<string> vc_url_sso_root = Column<string>.Text(size: 2048);
+
+    /// <summary>
+    /// Login URL for the SSO client.
+    /// </summary>
     public readonly Column<string> vc_url_sso_login = Column<string>.Text(size: 2048);
+
+    /// <summary>
+    /// Back-channel logout URL for the SSO client.
+    /// </summary>
     public readonly Column<string> vc_url_sso_backchannel_logout = Column<string>.Text(size: 2048);
+
+    /// <summary>
+    /// Logged-out redirect URL for the SSO client.
+    /// </summary>
     public readonly Column<string> vc_url_sso_logged_out = Column<string>.Text(size: 2048);
 
+    /// <summary>
+    /// Foreign key relation to the parent application.
+    /// </summary>
     public readonly EntityForeignKey<Applications, ApplicationOidcClients> FKApplicationsClients = new();
+
+    /// <summary>
+    /// Foreign key relation to the user owning the client.
+    /// </summary>
     public readonly EntityForeignKey<MicromUsers, ApplicationOidcClients> FKApplicationClientsUser = new();
 
 }
 
+/// <summary>
+/// Entity for managing OIDC client registrations for applications.
+/// </summary>
 public class ApplicationOidcClients : Entity<ApplicationOidcClientsDef>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationOidcClients"/> class.
+    /// </summary>
     public ApplicationOidcClients() : base() { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationOidcClients"/> class with the specified client and encryption provider.
+    /// </summary>
+    /// <param name="ec">Entity client used for data access.</param>
+    /// <param name="encryptor">Optional encryption provider.</param>
     public ApplicationOidcClients(IEntityClient ec, IMicroMEncryption? encryptor = null) : base(ec, encryptor) { }
 
 }

--- a/MicroM/core/DataDictionary/Entities/ApplicationOIDCServer/ApplicationOidcServer.cs
+++ b/MicroM/core/DataDictionary/Entities/ApplicationOIDCServer/ApplicationOidcServer.cs
@@ -4,26 +4,67 @@ using MicroM.Web.Services;
 
 namespace MicroM.DataDictionary;
 
+/// <summary>
+/// Schema definition for OIDC server settings for an application.
+/// </summary>
 public class ApplicationOidcServerDef : EntityDefinition
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationOidcServerDef"/> class.
+    /// </summary>
     public ApplicationOidcServerDef() : base("aois", nameof(ApplicationOidcServer)) { SQLCreationOptions = SQLCreationOptionsMetadata.WithIUpdate; }
 
+    /// <summary>
+    /// Application identifier.
+    /// </summary>
     public readonly Column<string> c_application_id = Column<string>.PK();
 
+    /// <summary>
+    /// Well-known configuration URL.
+    /// </summary>
     public readonly Column<string?> vc_url_wellknown = Column<string?>.Text(size: 2048, nullable: true);
 
-    // if acting as an IDP, these are the URLs to the OIDC endpoints
+    /// <summary>
+    /// JWKS endpoint URL when acting as an identity provider.
+    /// </summary>
     public readonly Column<string?> vc_url_jwks = Column<string?>.Text(size: 2048, nullable: true);
+
+    /// <summary>
+    /// Authorization endpoint URL when acting as an identity provider.
+    /// </summary>
     public readonly Column<string?> vc_url_authorize = Column<string?>.Text(size: 2048, nullable: true);
+
+    /// <summary>
+    /// Token endpoint URL for back-channel requests.
+    /// </summary>
     public readonly Column<string?> vc_url_token_backchannel = Column<string?>.Text(size: 2048, nullable: true);
+
+    /// <summary>
+    /// End session endpoint URL.
+    /// </summary>
     public readonly Column<string?> vc_url_endsession = Column<string?>.Text(size: 2048, nullable: true);
 
+    /// <summary>
+    /// Foreign key relation to the parent application.
+    /// </summary>
     public readonly EntityForeignKey<Applications, ApplicationOidcServer> FKApplicationsClients = new();
 }
 
+/// <summary>
+/// Entity for managing OIDC server configuration for applications.
+/// </summary>
 public class ApplicationOidcServer : Entity<ApplicationOidcServerDef>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationOidcServer"/> class.
+    /// </summary>
     public ApplicationOidcServer() : base() { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationOidcServer"/> class with the specified client and encryption provider.
+    /// </summary>
+    /// <param name="ec">Entity client used for data access.</param>
+    /// <param name="encryptor">Optional encryption provider.</param>
     public ApplicationOidcServer(IEntityClient ec, IMicroMEncryption? encryptor = null) : base(ec, encryptor) { }
 
 }

--- a/MicroM/core/DataDictionary/Entities/MicromUsers/LoginAttemptResult.cs
+++ b/MicroM/core/DataDictionary/Entities/MicromUsers/LoginAttemptResult.cs
@@ -1,10 +1,24 @@
 ﻿
 namespace MicroM.DataDictionary.Entities.MicromUsers
 {
+    /// <summary>
+    /// Result returned after attempting to log in.
+    /// </summary>
     public record LoginAttemptResult
     {
+        /// <summary>
+        /// Status of the login attempt.
+        /// </summary>
         public LoginAttemptStatus Status { get; set; } = LoginAttemptStatus.Unknown;
+
+        /// <summary>
+        /// Optional message describing the result.
+        /// </summary>
         public string? Message { get; set; } = null;
+
+        /// <summary>
+        /// Refresh token issued when the attempt succeeds.
+        /// </summary>
         public string? RefreshToken { get; set; } = null;
     }
 

--- a/MicroM/core/DataDictionary/Entities/MicromUsers/LoginAttemptStatus.cs
+++ b/MicroM/core/DataDictionary/Entities/MicromUsers/LoginAttemptStatus.cs
@@ -1,16 +1,58 @@
-﻿namespace MicroM.DataDictionary.Entities.MicromUsers
+namespace MicroM.DataDictionary.Entities.MicromUsers
 {
+    /// <summary>
+    /// Status codes representing the outcome of a login attempt.
+    /// </summary>
     public enum LoginAttemptStatus
     {
+        /// <summary>
+        /// Login state was updated successfully.
+        /// </summary>
         Updated = 0,
+
+        /// <summary>
+        /// Provided refresh token is invalid.
+        /// </summary>
         InvalidRefreshToken = 8,
+
+        /// <summary>
+        /// Refresh token has expired.
+        /// </summary>
         RefreshTokenExpired = 9,
+
+        /// <summary>
+        /// Maximum number of refresh attempts reached.
+        /// </summary>
         MaxRefreshReached = 10,
+
+        /// <summary>
+        /// User identifier was not found.
+        /// </summary>
         UserIDNotFound = 11,
+
+        /// <summary>
+        /// Account is locked.
+        /// </summary>
         AccountLocked = 13,
+
+        /// <summary>
+        /// Account is disabled.
+        /// </summary>
         AccountDisabled = 14,
+
+        /// <summary>
+        /// Refresh token is valid.
+        /// </summary>
         RefreshTokenValid = 15,
+
+        /// <summary>
+        /// Login succeeded.
+        /// </summary>
         LoggedInOK = 16,
+
+        /// <summary>
+        /// Unknown result.
+        /// </summary>
         Unknown = -1
     }
 

--- a/MicroM/core/DataDictionary/Entities/MicromUsers/LoginData.cs
+++ b/MicroM/core/DataDictionary/Entities/MicromUsers/LoginData.cs
@@ -1,20 +1,73 @@
-﻿namespace MicroM.DataDictionary.Entities.MicromUsers
+namespace MicroM.DataDictionary.Entities.MicromUsers;
+
+/// <summary>
+/// Represents authentication and status information retrieved for a user.
+/// </summary>
+public record LoginData
 {
-    public record LoginData
-    {
-        public string user_id { get; set; } = "";
-        public bool locked { get; set; } = true;
-        public string pwhash { get; set; } = "";
-        public int badlogonattempts { get; set; } = 0;
-        public int locked_minutes_remaining { get; set; } = 0;
-        public string? email { get; set; }
-        public string username { get; set; } = "";
-        public bool disabled { get; set; } = true;
-        public string? refresh_token { get; set; }
-        public bool refresh_expired { get; set; } = true;
-        public string? usertype_id { get; set; }
-        public string? usertype_name { get; set; }
-        // This will be a json string array of strings
-        public string? user_groups { get; set; }
-    }
+    /// <summary>
+    /// Unique identifier of the user.
+    /// </summary>
+    public string user_id { get; set; } = "";
+
+    /// <summary>
+    /// Indicates whether the account is locked.
+    /// </summary>
+    public bool locked { get; set; } = true;
+
+    /// <summary>
+    /// Hash of the user's password.
+    /// </summary>
+    public string pwhash { get; set; } = "";
+
+    /// <summary>
+    /// Number of failed login attempts.
+    /// </summary>
+    public int badlogonattempts { get; set; } = 0;
+
+    /// <summary>
+    /// Minutes remaining before the lockout expires.
+    /// </summary>
+    public int locked_minutes_remaining { get; set; } = 0;
+
+    /// <summary>
+    /// Email address associated with the account.
+    /// </summary>
+    public string? email { get; set; }
+
+    /// <summary>
+    /// Username for the account.
+    /// </summary>
+    public string username { get; set; } = "";
+
+    /// <summary>
+    /// Indicates whether the account is disabled.
+    /// </summary>
+    public bool disabled { get; set; } = true;
+
+    /// <summary>
+    /// Refresh token issued to the user.
+    /// </summary>
+    public string? refresh_token { get; set; }
+
+    /// <summary>
+    /// Indicates if the refresh token has expired.
+    /// </summary>
+    public bool refresh_expired { get; set; } = true;
+
+    /// <summary>
+    /// Identifier of the user type.
+    /// </summary>
+    public string? usertype_id { get; set; }
+
+    /// <summary>
+    /// Name of the user type.
+    /// </summary>
+    public string? usertype_name { get; set; }
+
+    /// <summary>
+    /// JSON array string of groups the user belongs to.
+    /// </summary>
+    public string? user_groups { get; set; }
 }
+

--- a/MicroM/core/DataDictionary/Entities/MicromUsers/LoginResult.cs
+++ b/MicroM/core/DataDictionary/Entities/MicromUsers/LoginResult.cs
@@ -4,12 +4,34 @@ using MicroM.Web.Authentication;
 
 namespace MicroM.DataDictionary.Entities.MicromUsers
 {
+    /// <summary>
+    /// Result returned after a successful login.
+    /// </summary>
     public record LoginResult
     {
+        /// <summary>
+        /// Email associated with the user.
+        /// </summary>
         public string? email { get; set; }
+
+        /// <summary>
+        /// Username of the authenticated user.
+        /// </summary>
         public string username { get; set; } = "";
+
+        /// <summary>
+        /// Refresh token issued for the session.
+        /// </summary>
         public string? refresh_token { get; set; }
+
+        /// <summary>
+        /// Client-specific claims included in the login response.
+        /// </summary>
         public Dictionary<string, string> client_claims { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Result of the authenticator challenge, if any.
+        /// </summary>
         public AuthenticatorResult authenticator_result { get; set; } = new();
     }
 }

--- a/MicroM/core/DataDictionary/Entities/MicromUsers/RefreshResult.cs
+++ b/MicroM/core/DataDictionary/Entities/MicromUsers/RefreshResult.cs
@@ -1,14 +1,28 @@
-﻿
+namespace MicroM.DataDictionary.Entities.MicromUsers;
 
-namespace MicroM.DataDictionary.Entities.MicromUsers
+/// <summary>
+/// Result of a refresh token request.
+/// </summary>
+public record RefreshTokenResult
 {
-    public record RefreshTokenResult
-    {
-        public LoginAttemptStatus Status { get; set; } = LoginAttemptStatus.Unknown;
-        public string? Message { get; set; } = null;
-        public string? RefreshToken { get; set; } = null;
-        public DateTime? RefreshExpiration { get; set; } = null;
-    }
+    /// <summary>
+    /// Outcome of the refresh attempt.
+    /// </summary>
+    public LoginAttemptStatus Status { get; set; } = LoginAttemptStatus.Unknown;
 
+    /// <summary>
+    /// Optional message describing the result.
+    /// </summary>
+    public string? Message { get; set; } = null;
 
+    /// <summary>
+    /// Newly issued refresh token.
+    /// </summary>
+    public string? RefreshToken { get; set; } = null;
+
+    /// <summary>
+    /// Expiration time for the refresh token.
+    /// </summary>
+    public DateTime? RefreshExpiration { get; set; } = null;
 }
+


### PR DESCRIPTION
## Summary
- document additional MicromUsers records (LoginData and RefreshTokenResult)
- add corresponding pages and link them in namespace index
- update documentation progress tracking

## Testing
- `dotnet test` *(fails: del command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a77bc29e308324971eedf5e5fc82f8