### PR TITLE
docs: document MicroM.Core types

### DIFF
--- a/MicroM/Documentation-Progress/Backend/docs-state-backend.md
+++ b/MicroM/Documentation-Progress/Backend/docs-state-backend.md
@@ -11,8 +11,8 @@ This file tracks the current documentation state of the backend (`/MicroM/core`)
 - Notes: Namespace and classes documented.
 
 ### MicroM.Core
-- State: Incomplete ⚠️
-- Notes: Namespace index and some types documented; additional types require documentation.
+- State: Complete ✅
+- Notes: Namespace and all public types documented with XML comments and pages.
 
 ### MicroM.Data
 - State: Incomplete ⚠️

--- a/MicroM/Documentation/Backend/MicroM.Core/CryptClass/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Core/CryptClass/index.md
@@ -1,0 +1,39 @@
+# Class: MicroM.Core.CryptClass
+## Overview
+Cryptographic helper utilities.
+
+**Inheritance**
+object -> CryptClass
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+var key = CryptClass.GenerateRandomBase64String();
+```
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| TempEncryptString(string to_encrypt) | Encrypts a string using a temporary AES key. |
+| GetSecurityKey(string password, string salt, int keySize) | Derives a symmetric security key. |
+| EncryptText(string text, byte[] key, byte[] iv) | Encrypts text with AES. |
+| CreateSelfSignedCertificate(string distinguished_name, int expires_years) | Creates a self-signed certificate. |
+| ExportCertificate(X509Certificate2 cert, string certificate_full_path, string export_password, CancellationToken ct) | Exports a certificate to a file. |
+| StoreCertificate(X509Certificate2 certificate, string certificate_password) | Stores a certificate in the user's store. |
+| CreateSelfSignedCertificateAndStoreInUser(string certificate_password, string distinguished_name, int expires_years) | Creates and stores a certificate. |
+| DeleteCertificate(string subject_name) | Deletes a certificate from the user store. |
+| FindCertificateByName(string subject_name) | Finds a certificate by subject name. |
+| FindCertificate(string thumbprint) | Finds a certificate by thumbprint. |
+| X509Encrypt(string plainText, X509Certificate2 cert) | Encrypts text using an X509 certificate. |
+| X509Decrypt(string encryptedText, X509Certificate2 cert) | Decrypts text using an X509 certificate. |
+| GenerateRandomBase64String(int count) | Generates random base64 data. |
+| CreateRandomPassword(int length, int minSymbols, int minNumbers, int minUppercase, int minLowercase) | Creates a random password. |
+| EncryptObject<T>(T obj, X509Certificate2 cert) | Encrypts an object and returns a base64 string. |
+| DecryptObject<T>(string encryptedString, X509Certificate2 cert) | Decrypts an object from a base64 string. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Core/EmptyActionResult/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Core/EmptyActionResult/index.md
@@ -1,0 +1,19 @@
+# Class: MicroM.Core.EmptyActionResult
+## Overview
+Represents an empty action result.
+
+**Inheritance**
+[EntityActionResult](../EntityActionResult/index.md) -> EmptyActionResult
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+var result = new EmptyActionResult();
+```
+## Remarks
+None.
+
+## See Also
+- [EntityActionResult](../EntityActionResult/index.md)

--- a/MicroM/Documentation/Backend/MicroM.Core/Entity/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Core/Entity/index.md
@@ -1,0 +1,41 @@
+# Class: MicroM.Core.Entity<TDefinition>
+## Overview
+Generic entity base providing a strongly typed definition.
+
+### Type Parameters
+| Parameter | Description |
+|:------------|:-------------|
+|TDefinition|Entity definition type.|
+
+**Inheritance**
+[EntityBase](EntityBase/index.md) -> Entity<TDefinition>
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+var entity = new MyEntity();
+```
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| Entity() | Initializes a new entity. |
+| Entity(string table_name) | Initializes the entity with a table name. |
+| Entity(IEntityClient ec, IMicroMEncryption? encryptor) | Initializes the entity with a client and encryptor. |
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| Def | TDefinition | Strongly typed definition. |
+
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| None |
+
+## Remarks
+None.
+
+## See Also
+- [EntityBase](EntityBase/index.md)

--- a/MicroM/Documentation/Backend/MicroM.Core/EntityActionArguments/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Core/EntityActionArguments/index.md
@@ -1,0 +1,24 @@
+# Class: MicroM.Core.EntityActionArguments
+## Overview
+Arguments supplied to entity actions.
+
+**Inheritance**
+object -> EntityActionArguments
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+var args = new EntityActionArguments { WebParms = request };
+```
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| WebParms | DataWebAPIRequest | Web request parameters. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Core/EntityActionBase/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Core/EntityActionBase/index.md
@@ -1,0 +1,28 @@
+# Class: MicroM.Core.EntityActionBase
+## Overview
+Base class for custom entity actions.
+
+**Inheritance**
+object -> EntityActionBase
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+class MyAction : EntityActionBase {
+    public override Task<EntityActionResult> Execute(EntityBase e, DataWebAPIRequest p, EntityDefinition d, MicroMOptions? o, IWebAPIServices? a, IMicroMEncryption? enc, CancellationToken ct, string? app) {
+        return Task.FromResult<EntityActionResult>(new EmptyActionResult());
+    }
+}
+```
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| Execute(EntityBase entity, DataWebAPIRequest parms, EntityDefinition def, MicroMOptions? Options, IWebAPIServices? API, IMicroMEncryption? encryptor, CancellationToken ct, string? app_id) | Executes the action. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Core/EntityActionResult/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Core/EntityActionResult/index.md
@@ -1,0 +1,19 @@
+# Class: MicroM.Core.EntityActionResult
+## Overview
+Base record for action results returned by entity actions.
+
+**Inheritance**
+object -> EntityActionResult
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+EntityActionResult result = new EmptyActionResult();
+```
+## Remarks
+None.
+
+## See Also
+- [EmptyActionResult](../EmptyActionResult/index.md)

--- a/MicroM/Documentation/Backend/MicroM.Core/EntityBase/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Core/EntityBase/index.md
@@ -1,0 +1,46 @@
+# Class: MicroM.Core.EntityBase
+## Overview
+Base class for entities providing initialization and data access helpers.
+
+**Inheritance**
+[InitBase](InitBase/index.md) -> EntityBase
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+var entity = new MyEntity();
+entity.Init(client);
+```
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| Def | EntityDefinition | Entity definition. |
+| Client | IEntityClient | Data access client. |
+| Encryptor | IMicroMEncryption? | Encryption provider. |
+| Actions | Dictionary<string, Action> | Registered actions. |
+
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| Init(IEntityClient? ec, IMicroMEncryption? encryptor) | Initializes the entity. |
+| ExecuteAction(string action_name, DataWebAPIRequest args, MicroMOptions? Options, IWebAPIServices? API, IMicroMEncryption? encryptor, CancellationToken ct, string? app_id) | Executes a registered action. |
+| DeleteData(...) | Deletes entity data. |
+| ExecuteView(...) | Executes a view and returns results. |
+| GetData(...) | Retrieves entity data. |
+| GetData<T>(...) | Retrieves entity data mapped to a type. |
+| InsertData(...) | Inserts entity data. |
+| LookupData(...) | Performs a lookup. |
+| UpdateData(...) | Updates entity data. |
+| ExecuteProcessDBStatus(...) | Executes a procedure returning DBStatus. |
+| ExecuteProc(...) | Executes a procedure returning results. |
+| ExecuteProc<T>(...) | Executes a procedure returning mapped results. |
+| ExecuteProcSingleColumn<T>(...) | Executes a procedure returning a single column. |
+| ExecuteProcSingleRow<T>(...) | Executes a procedure returning a single row. |
+
+## Remarks
+None.
+
+## See Also
+- [InitBase](InitBase/index.md)

--- a/MicroM/Documentation/Backend/MicroM.Core/EntityChecker/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Core/EntityChecker/index.md
@@ -1,0 +1,26 @@
+# Class: MicroM.Core.EntityChecker
+## Overview
+Utilities to validate entity definitions and relationships.
+
+**Inheritance**
+object -> EntityChecker
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+EntityChecker.CheckEntities();
+```
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| CheckEntity(Type entity_type) | Validates a single entity type. |
+| GetProperties(Type entity) | Retrieves column, view and procedure properties. |
+| CheckEntities(Assembly? asm, string? assembly_name) | Validates all entities in an assembly. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Core/EntityDefinition/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Core/EntityDefinition/index.md
@@ -1,0 +1,66 @@
+# Class: MicroM.Core.EntityDefinition
+## Overview
+Defines the structure and metadata of an entity.
+
+**Inheritance**
+object -> EntityDefinition
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+class MyDefinition : EntityDefinition {
+    public MyDefinition() : base("MN", nameof(MyEntity)) {}
+}
+```
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| EntityDefinition(string mneo, string name, bool add_default_columns, bool webusr_delete_flag) | Base constructor for definitions. |
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| Mneo | string | Mnemonic code for procedures. |
+| Name | string | Class name. |
+| TableName | string | Table name in SQL Server. |
+| Fake | bool | Indicates a fake entity. |
+| SQLCreationOptions | SQLCreationOptionsMetadata | SQL generation options. |
+| Columns | IReadonlyOrderedDictionary<ColumnBase> | Columns for the entity. |
+| KeyColumnName | string | Primary key column name. |
+| Views | IReadOnlyDictionary<string, ViewDefinition> | Defined views. |
+| Procs | IReadOnlyDictionary<string, ProcedureDefinition> | Defined procedures. |
+| ForeignKeys | IReadOnlyDictionary<string, EntityForeignKeyBase> | Foreign keys. |
+| Actions | IReadOnlyDictionary<string, EntityActionBase> | Entity actions. |
+| UniqueConstraints | IReadOnlyDictionary<string, EntityUniqueConstraint> | Unique constraints. |
+| Indexes | IReadOnlyDictionary<string, EntityIndex> | Indexes. |
+| AutonumColumn | ColumnBase | Auto-number column. |
+| dt_inserttime | Column<DateTime> | Creation timestamp. |
+| dt_lu | Column<DateTime> | Last update timestamp. |
+| vc_webinsuser | Column<string> | Creating web user. |
+| vc_webluuser | Column<string> | Updating web user. |
+| vc_insuser | Column<string> | Creating AD user. |
+| vc_luuser | Column<string> | Updating AD user. |
+| webusr | Column<string> | Creating web user name. |
+| RelatedCategories | IReadOnlySet<string> | Related category IDs. |
+| RelatedStatus | IReadOnlySet<string> | Related status IDs. |
+
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| GetForeignKey<T>(T parent_entity) | Gets foreign key relating to a parent entity. |
+| AddCategoryID(string category_id) | Relates a category with the entity. |
+| AddStatusID(string status_id) | Relates a status with the entity. |
+| DefineActions() | Adds custom actions (override). |
+| AddCategoriesRelations() | Adds category relations (override). |
+| AddStatusRelations() | Adds status relations (override). |
+| DefineViews() | Adds view definitions (override). |
+| DefineProcs() | Adds procedure definitions (override). |
+| DefineConstraints() | Adds foreign key and constraint definitions (override). |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Core/InitBase/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Core/InitBase/index.md
@@ -1,0 +1,31 @@
+# Class: MicroM.Core.InitBase
+## Overview
+Provides lazy initialization support for derived classes.
+
+**Inheritance**
+object -> InitBase
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+class MyClass : InitBase {
+    public void Init() { IsInitialized = true; }
+}
+```
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| IsInitialized | bool | Indicates whether initialization occurred. |
+
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| CheckInit() | Throws if the class has not been initialized. |
+
+## Remarks
+None.
+
+## See Also
+- [EntityBase](../EntityBase/index.md)

--- a/MicroM/Documentation/Backend/MicroM.Core/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Core/index.md
@@ -5,9 +5,19 @@ Core utilities and abstractions.
 ## Classes
 | Class | Description |
 |:------------|:-------------|
-| [CRC32](CRC32/index.md) | CRC-32 checksum utilities. |
 | [ClassNotInitilizedException](ClassNotInitilizedException/index.md) | Exception thrown when a class is used before initialization. |
+| [CRC32](CRC32/index.md) | CRC-32 checksum utilities. |
+| [CryptClass](CryptClass/index.md) | Cryptographic helper utilities. |
 | [CustomOrderedDictionary](CustomOrderedDictionary/index.md) | Ordered dictionary with case-insensitive keys. |
+| [EmptyActionResult](EmptyActionResult/index.md) | Represents an empty action result. |
+| [Entity](Entity/index.md) | Generic entity base. |
+| [EntityActionArguments](EntityActionArguments/index.md) | Arguments supplied to entity actions. |
+| [EntityActionBase](EntityActionBase/index.md) | Base class for entity actions. |
+| [EntityActionResult](EntityActionResult/index.md) | Base record for action results. |
+| [EntityBase](EntityBase/index.md) | Base class providing entity data helpers. |
+| [EntityChecker](EntityChecker/index.md) | Utilities to validate entity definitions. |
+| [EntityDefinition](EntityDefinition/index.md) | Defines structure and metadata of an entity. |
+| [InitBase](InitBase/index.md) | Provides lazy initialization support. |
 | [X509Encryptor](X509Encryptor/index.md) | Encryption and decryption using X509 certificates. |
 
 ## Enums

--- a/MicroM/core/Core/CryptClass.cs
+++ b/MicroM/core/Core/CryptClass.cs
@@ -7,8 +7,16 @@ using System.Text.Json;
 
 namespace MicroM.Core
 {
+    /// <summary>
+    /// Provides cryptographic helper methods.
+    /// </summary>
     public class CryptClass
     {
+        /// <summary>
+        /// Temporarily encrypts a string using a random AES key.
+        /// </summary>
+        /// <param name="to_encrypt">Text to encrypt.</param>
+        /// <returns>Encrypted bytes.</returns>
         public static async Task<byte[]> TempEncryptString(string to_encrypt)
         {
             using var aes = Aes.Create();
@@ -18,6 +26,9 @@ namespace MicroM.Core
             return await EncryptText(to_encrypt, SecurityDefaults.TempEncryptionKey, SecurityDefaults.TempEncryptionIV);
         }
 
+        /// <summary>
+        /// Derives a symmetric security key from a password and salt.
+        /// </summary>
         public static SymmetricSecurityKey GetSecurityKey(string password, string salt, int keySize = 256)
         {
             var pbkdf2 = new Rfc2898DeriveBytes(password, Encoding.UTF8.GetBytes(salt), 1000, HashAlgorithmName.SHA512);
@@ -27,6 +38,9 @@ namespace MicroM.Core
         }
 
 
+        /// <summary>
+        /// Encrypts text using AES with the provided key and IV.
+        /// </summary>
         public static async Task<byte[]> EncryptText(string text, byte[] key, byte[] iv)
         {
 
@@ -45,6 +59,9 @@ namespace MicroM.Core
 
         }
 
+        /// <summary>
+        /// Creates a self-signed X509 certificate.
+        /// </summary>
         public static X509Certificate2 CreateSelfSignedCertificate(string distinguished_name = ConfigurationDefaults.CertificateSubjectName, int expires_years = 50)
         {
             using var rsa = RSA.Create(2048);
@@ -69,12 +86,18 @@ namespace MicroM.Core
 
         }
 
+        /// <summary>
+        /// Exports a certificate to a PFX file.
+        /// </summary>
         public static async Task ExportCertificate(X509Certificate2 cert, string certificate_full_path, string export_password, CancellationToken ct)
         {
             if (!Directory.Exists(certificate_full_path)) Directory.CreateDirectory(certificate_full_path);
             await File.WriteAllBytesAsync(certificate_full_path, cert.Export(X509ContentType.Pkcs12, export_password), ct);
         }
 
+        /// <summary>
+        /// Stores a certificate in the current user's certificate store.
+        /// </summary>
         public static X509Certificate2 StoreCertificate(X509Certificate2 certificate, string certificate_password)
         {
             // Export the certificate to a PFX file, to create with a password
@@ -93,6 +116,9 @@ namespace MicroM.Core
 
         }
 
+        /// <summary>
+        /// Creates a self-signed certificate and stores it in the current user's store.
+        /// </summary>
         public static X509Certificate2 CreateSelfSignedCertificateAndStoreInUser(string certificate_password, string distinguished_name = ConfigurationDefaults.CertificateSubjectName, int expires_years = 50)
         {
 
@@ -101,6 +127,9 @@ namespace MicroM.Core
         }
 
 
+        /// <summary>
+        /// Deletes a certificate by subject name from the current user's store.
+        /// </summary>
         public static bool DeleteCertificate(string subject_name)
         {
             bool ret = false;
@@ -144,6 +173,9 @@ namespace MicroM.Core
             return null;
         }
 
+        /// <summary>
+        /// Finds a certificate by subject name.
+        /// </summary>
         public static X509Certificate2? FindCertificateByName(string subject_name)
         {
             return Find(X509FindType.FindBySubjectName, subject_name);
@@ -151,11 +183,17 @@ namespace MicroM.Core
         }
 
 
+        /// <summary>
+        /// Finds a certificate by thumbprint.
+        /// </summary>
         public static X509Certificate2? FindCertificate(string thumbprint)
         {
             return Find(X509FindType.FindByThumbprint, thumbprint);
         }
 
+        /// <summary>
+        /// Encrypts text using the public key of the certificate.
+        /// </summary>
         public static string? X509Encrypt(string plainText, X509Certificate2 cert)
         {
             // Get the public key from the certificate
@@ -169,6 +207,9 @@ namespace MicroM.Core
             return encryptedData == null ? null : Convert.ToBase64String(encryptedData);
         }
 
+        /// <summary>
+        /// Decrypts text using the private key of the certificate.
+        /// </summary>
         public static string? X509Decrypt(string encryptedText, X509Certificate2 cert)
         {
             // Get the private key from the certificate
@@ -182,6 +223,9 @@ namespace MicroM.Core
             return decryptedData == null ? null : Encoding.UTF8.GetString(decryptedData);
         }
 
+        /// <summary>
+        /// Generates a random base64 string of the specified byte length.
+        /// </summary>
         public static string GenerateRandomBase64String(int count = 8)
         {
             byte[] bytes = RandomNumberGenerator.GetBytes(count);
@@ -189,6 +233,9 @@ namespace MicroM.Core
             return Convert.ToBase64String(bytes);
         }
 
+        /// <summary>
+        /// Creates a random password satisfying the specified requirements.
+        /// </summary>
         public static string CreateRandomPassword(int length = 50, int minSymbols = 5, int minNumbers = 5, int minUppercase = 5, int minLowercase = 5)
         {
             ReadOnlySpan<char> symbols = "!@#$%^&*()_-+=[]{};:>|./?";
@@ -243,6 +290,9 @@ namespace MicroM.Core
             return span;
         }
 
+        /// <summary>
+        /// Encrypts an object using hybrid RSA/AES and returns a base64 string.
+        /// </summary>
         public static string EncryptObject<T>(T obj, X509Certificate2 cert)
         {
             var rsaParams = (cert.GetRSAPublicKey()?.ExportParameters(false)) ?? throw new Exception("Could not get RSA parameters from certificate");
@@ -282,6 +332,9 @@ namespace MicroM.Core
             return Convert.ToBase64String(result);
         }
 
+        /// <summary>
+        /// Decrypts a previously encrypted object.
+        /// </summary>
         public static T? DecryptObject<T>(string encryptedString, X509Certificate2 cert)
         {
             byte[] data = Convert.FromBase64String(encryptedString);

--- a/MicroM/core/Core/Entity.cs
+++ b/MicroM/core/Core/Entity.cs
@@ -3,15 +3,25 @@ using MicroM.Web.Services;
 
 namespace MicroM.Core
 {
-    
+    /// <summary>
+    /// Provides a strongly-typed entity base that exposes a definition of type
+    /// <typeparamref name="TDefinition"/>.
+    /// </summary>
+    /// <typeparam name="TDefinition">The entity definition type.</typeparam>
     public abstract class Entity<TDefinition> : EntityBase where TDefinition : EntityDefinition, new()
     {
+        /// <summary>
+        /// Gets the strongly typed definition for this entity.
+        /// </summary>
         public new TDefinition Def
         {
             get => (TDefinition)base.Def;
             protected set => base.Def = value;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Entity{TDefinition}"/> class.
+        /// </summary>
         public Entity()
         {
             Def = new TDefinition();
@@ -19,6 +29,10 @@ namespace MicroM.Core
             Init(null);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Entity{TDefinition}"/> class using the specified table name.
+        /// </summary>
+        /// <param name="table_name">The table name to associate with the entity definition.</param>
         public Entity(string table_name)
         {
             Def = new TDefinition() { TableName = table_name };
@@ -26,6 +40,11 @@ namespace MicroM.Core
             Init(null);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Entity{TDefinition}"/> class using the provided client and encryptor.
+        /// </summary>
+        /// <param name="ec">Entity client used for data access.</param>
+        /// <param name="encryptor">Optional encryption provider.</param>
         public Entity(IEntityClient ec, IMicroMEncryption? encryptor)
         {
             Def = new TDefinition();

--- a/MicroM/core/Core/EntityActionArguments.cs
+++ b/MicroM/core/Core/EntityActionArguments.cs
@@ -2,8 +2,14 @@
 
 namespace MicroM.Core
 {
+    /// <summary>
+    /// Encapsulates arguments passed to an entity action.
+    /// </summary>
     public record EntityActionArguments
     {
+        /// <summary>
+        /// Gets the web request parameters for the action.
+        /// </summary>
         public required DataWebAPIRequest WebParms { get; init; }
     }
 }

--- a/MicroM/core/Core/EntityActionBase.cs
+++ b/MicroM/core/Core/EntityActionBase.cs
@@ -4,8 +4,23 @@ using MicroM.Web.Services;
 
 namespace MicroM.Core
 {
+    /// <summary>
+    /// Base class for entity actions.
+    /// </summary>
     public abstract class EntityActionBase
     {
+        /// <summary>
+        /// Executes the action.
+        /// </summary>
+        /// <param name="entity">The entity the action applies to.</param>
+        /// <param name="parms">Web request parameters.</param>
+        /// <param name="def">Entity definition.</param>
+        /// <param name="Options">Optional configuration.</param>
+        /// <param name="API">Optional web API services.</param>
+        /// <param name="encryptor">Optional encryption provider.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <param name="app_id">Optional application identifier.</param>
+        /// <returns>The action result.</returns>
         public abstract Task<EntityActionResult> Execute(EntityBase entity, DataWebAPIRequest parms, EntityDefinition def, MicroMOptions? Options, IWebAPIServices? API, IMicroMEncryption? encryptor, CancellationToken ct, string? app_id);
     }
 }

--- a/MicroM/core/Core/EntityActionResult.cs
+++ b/MicroM/core/Core/EntityActionResult.cs
@@ -1,10 +1,15 @@
 ﻿namespace MicroM.Core
 {
+    /// <summary>
+    /// Represents an empty action result.
+    /// </summary>
     public record EmptyActionResult : EntityActionResult
     {
-
     }
 
+    /// <summary>
+    /// Base record for action results returned by entity actions.
+    /// </summary>
     public abstract record EntityActionResult
     {
     }

--- a/MicroM/core/Core/EntityBase.cs
+++ b/MicroM/core/Core/EntityBase.cs
@@ -5,9 +5,15 @@ using static MicroM.Data.IEntityClient;
 
 namespace MicroM.Core
 {
+    /// <summary>
+    /// Base class for all entities providing initialization and data operations.
+    /// </summary>
     public abstract class EntityBase : InitBase
     {
 
+        /// <summary>
+        /// Gets the definition for this entity.
+        /// </summary>
         public EntityDefinition Def { get; protected set; } = null!;
 
 
@@ -18,11 +24,26 @@ namespace MicroM.Core
             set => _data = value;
         }
 
+        /// <summary>
+        /// Gets the <see cref="IEntityClient"/> used for data access.
+        /// </summary>
         public IEntityClient Client => Data.EntityClient;
+
+        /// <summary>
+        /// Gets the encryptor associated with this entity, if any.
+        /// </summary>
         public IMicroMEncryption? Encryptor => Data.Encryptor;
 
+        /// <summary>
+        /// Gets the collection of available actions.
+        /// </summary>
         public Dictionary<string, Action> Actions { get; private set; } = new(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// Initializes the entity with the specified client and optional encryptor.
+        /// </summary>
+        /// <param name="ec">Entity client used for data operations.</param>
+        /// <param name="encryptor">Optional encryption provider.</param>
         public virtual void Init(IEntityClient? ec, IMicroMEncryption? encryptor = null)
         {
             if (ec != null)
@@ -32,6 +53,17 @@ namespace MicroM.Core
             }
         }
 
+        /// <summary>
+        /// Executes a registered action for this entity.
+        /// </summary>
+        /// <param name="action_name">Name of the action to execute.</param>
+        /// <param name="args">Action arguments.</param>
+        /// <param name="Options">Optional configuration.</param>
+        /// <param name="API">Optional Web API services.</param>
+        /// <param name="encryptor">Optional encryption provider.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <param name="app_id">Optional application identifier.</param>
+        /// <returns>The action result or null if not found.</returns>
         public async Task<EntityActionResult?> ExecuteAction(string action_name, DataWebAPIRequest args, MicroMOptions? Options, IWebAPIServices? API, IMicroMEncryption? encryptor, CancellationToken ct, string? app_id = null)
         {
             EntityActionResult? result = null;
@@ -47,61 +79,97 @@ namespace MicroM.Core
 
         #region "Data API"
 
+        /// <summary>
+        /// Deletes entity data using the configured definition.
+        /// </summary>
         public virtual async Task<DBStatusResult> DeleteData(CancellationToken ct, bool throw_dbstat_exception = false, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null)
         {
             return await Data.DeleteData(ct, throw_dbstat_exception);
         }
 
+        /// <summary>
+        /// Executes a view and returns the resulting data set.
+        /// </summary>
         public virtual async Task<List<DataResult>> ExecuteView(CancellationToken ct, ViewDefinition view, int? row_limit = null, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null)
         {
             return await Data.ExecuteView(ct, view, row_limit);
         }
 
+        /// <summary>
+        /// Retrieves entity data.
+        /// </summary>
         public virtual async Task<bool> GetData(CancellationToken ct, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null)
         {
             return await Data.GetData(ct);
         }
 
+        /// <summary>
+        /// Retrieves entity data mapped to the specified type.
+        /// </summary>
         public virtual async Task<T?> GetData<T>(CancellationToken ct, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, AutoMapperMode mode = AutoMapperMode.ByNameLaxNotThrow, MapResult<T>? mapper = null, string? app_id = null) where T : class, new()
         {
             return await Data.GetData<T>(ct, mode, mapper);
         }
 
+        /// <summary>
+        /// Inserts entity data.
+        /// </summary>
         public virtual async Task<DBStatusResult> InsertData(CancellationToken ct, bool throw_dbstat_exception = false, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null)
         {
             return await Data.InsertData(ct, throw_dbstat_exception);
         }
 
+        /// <summary>
+        /// Performs a lookup and returns the resulting value.
+        /// </summary>
         public virtual async Task<string?> LookupData(CancellationToken ct, string? lookup_name = null, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null)
         {
             return await Data.LookupData(ct, lookup_name);
         }
 
+        /// <summary>
+        /// Updates entity data.
+        /// </summary>
         public virtual async Task<DBStatusResult> UpdateData(CancellationToken ct, bool throw_dbstat_exception = false, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null)
         {
             return await Data.UpdateData(ct, throw_dbstat_exception);
         }
 
+        /// <summary>
+        /// Executes a procedure that returns a <see cref="DBStatusResult"/>.
+        /// </summary>
         public virtual async Task<DBStatusResult> ExecuteProcessDBStatus(CancellationToken ct, ProcedureDefinition proc, bool set_parms_from_columns = true, bool throw_dbstat_exception = false, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null)
         {
             return await Data.ExecuteProcDBStatus(ct, proc, set_parms_from_columns, throw_dbstat_exception);
         }
 
+        /// <summary>
+        /// Executes a procedure and returns a list of <see cref="DataResult"/>.
+        /// </summary>
         public virtual async Task<List<DataResult>> ExecuteProc(CancellationToken ct, ProcedureDefinition proc, int row_limit = 0, bool set_parms_from_columns = true, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null)
         {
             return await Data.ExecuteProc(ct, proc, row_limit, set_parms_from_columns);
         }
 
+        /// <summary>
+        /// Executes a procedure and maps the results to the specified type.
+        /// </summary>
         public virtual async Task<List<T>> ExecuteProc<T>(CancellationToken ct, ProcedureDefinition proc, int row_limit = 0, bool set_parms_from_columns = true, IEntityClient.AutoMapperMode mode = IEntityClient.AutoMapperMode.ByName, IEntityClient.MapResult<T>? mapper = null, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null) where T : class, new()
         {
             return await Data.ExecuteProc<T>(ct, proc, row_limit, set_parms_from_columns, mode, mapper);
         }
 
+        /// <summary>
+        /// Executes a procedure and returns a single column value.
+        /// </summary>
         public virtual async Task<T?> ExecuteProcSingleColumn<T>(CancellationToken ct, ProcedureDefinition proc, int row_limit = 0, bool set_parms_from_columns = true, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null)
         {
             return await Data.ExecuteProcSingleColumn<T>(ct, proc, row_limit, set_parms_from_columns);
         }
 
+        /// <summary>
+        /// Executes a procedure and returns a single row mapped to the specified type.
+        /// </summary>
         public virtual async Task<T?> ExecuteProcSingleRow<T>(CancellationToken ct, ProcedureDefinition proc, bool set_parms_from_columns = true, IEntityClient.AutoMapperMode mode = IEntityClient.AutoMapperMode.ByName, IEntityClient.MapResult<T>? mapper = null, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null) where T : class, new()
         {
             return await Data.ExecuteProcSingleRow<T>(ct, proc, set_parms_from_columns, mode, mapper);

--- a/MicroM/core/Core/EntityChecker.cs
+++ b/MicroM/core/Core/EntityChecker.cs
@@ -5,9 +5,17 @@ using System.Text;
 
 namespace MicroM.Core
 {
+    /// <summary>
+    /// Provides utilities to validate entity definitions.
+    /// </summary>
     public class EntityChecker
     {
 
+        /// <summary>
+        /// Validates a single entity type.
+        /// </summary>
+        /// <param name="entity_type">The entity type to check.</param>
+        /// <returns>A string describing problems, if any.</returns>
         public static string CheckEntity(Type entity_type)
         {
             StringBuilder problems = new();
@@ -81,6 +89,9 @@ namespace MicroM.Core
             return problems.ToString();
         }
 
+        /// <summary>
+        /// Gets the column, view and procedure properties defined on an entity type.
+        /// </summary>
         public static
             (
             Dictionary<string, PropertyInfo> cols,
@@ -105,6 +116,11 @@ namespace MicroM.Core
             return ret;
         }
 
+        /// <summary>
+        /// Validates all entities in the specified assembly.
+        /// </summary>
+        /// <param name="asm">The assembly containing entities. If null, the executing assembly is used.</param>
+        /// <param name="assembly_name">Optional assembly name to load.</param>
         public static void CheckEntities(Assembly? asm = null, string? assembly_name = null)
         {
             if (asm == null && !string.IsNullOrEmpty(assembly_name)) asm = Assembly.Load(assembly_name);

--- a/MicroM/core/Core/EntityDefinition.cs
+++ b/MicroM/core/Core/EntityDefinition.cs
@@ -45,6 +45,9 @@ namespace MicroM.Core
         /// </summary>
         public bool Fake { get; init; } = false;
 
+        /// <summary>
+        /// Options used when generating SQL for this entity.
+        /// </summary>
         public SQLCreationOptionsMetadata SQLCreationOptions = SQLCreationOptionsMetadata.None;
 
         private readonly CustomOrderedDictionary<ColumnBase> _Columns = new();


### PR DESCRIPTION
## Summary
- add missing XML comments for core entity utilities
- create documentation pages for MicroM.Core types
- mark MicroM.Core namespace as fully documented

## Testing
- `dotnet build MicroM/core/MicroMCore.csproj` *(fails: NuGet.Config is not valid XML)*

------
https://chatgpt.com/codex/tasks/task_e_68a7816b366883248c9e435b5425f414