### PR TITLE
docs: add StatusDefs namespace docs

### DIFF
--- a/MicroM/Documentation-Progress/Backend/docs-state-backend.md
+++ b/MicroM/Documentation-Progress/Backend/docs-state-backend.md
@@ -39,8 +39,8 @@ This file tracks the current documentation state of the backend (`/MicroM/core`)
 - Notes: Namespace index with LoginResult, LoginAttemptResult, LoginAttemptStatus, LoginData, and RefreshTokenResult documented.
 
 ### MicroM.DataDictionary.StatusDefs
-- State: Not Started ❌
-- Notes: No documentation present.
+- State: Incomplete ⚠️
+- Notes: Namespace index documented; class pages and XML comments pending.
 
 ### MicroM.Database
 - State: Not Started ❌

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.StatusDefs/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.StatusDefs/index.md
@@ -1,0 +1,30 @@
+# Namespace: MicroM.DataDictionary.StatusDefs
+## Overview
+Provides status definitions for core operations such as emails, file uploads, data imports, and generic processes.
+
+## Classes
+| Class | Description |
+|:------------|:-------------|
+| [EmailStatus](EmailStatus/index.md) | Status values for the email sending pipeline. |
+| [FileUpload](FileUpload/index.md) | Tracks stages of a file upload. |
+| [ImportStatus](ImportStatus/index.md) | Represents states of data import operations. |
+| [ProcessStatus](ProcessStatus/index.md) | Basic start and completion flags for a process. |
+
+## Enums
+| Enum | Description |
+|:------------|:-------------|
+
+## Structs
+| Struct | Description |
+|:------------|:-------------|
+
+## Interfaces
+| Interface | Description |
+|:------------|:-------------|
+
+## Remarks
+Each status definition derives from `StatusDefinition` and exposes named `StatusValuesDefinition` fields indicating possible states.
+
+## See Also
+- [MicroM.DataDictionary](../MicroM.DataDictionary/index.md)
+- [MicroM.DataDictionary.Configuration](../MicroM.DataDictionary.Configuration/index.md)

--- a/MicroM/Documentation/Backend/index.md
+++ b/MicroM/Documentation/Backend/index.md
@@ -13,7 +13,7 @@ This section provides documentation for the MicroM backend namespaces.
 | [MicroM.DataDictionary.Configuration](MicroM.DataDictionary.Configuration/index.md) | Configuration helpers and definitions for categories, statuses, menus and groups. |
 | [MicroM.DataDictionary.Entities](MicroM.DataDictionary.Entities/index.md) | Data dictionary entities like configuration parameters. |
 | [MicroM.DataDictionary.Entities.MicromUsers](MicroM.DataDictionary.Entities.MicromUsers/index.md) | Authentication-related entity helpers and results. |
-| MicroM.DataDictionary.StatusDefs | Documentation not started. |
+| [MicroM.DataDictionary.StatusDefs](MicroM.DataDictionary.StatusDefs/index.md) | Status definitions for emails, file uploads, imports, and processes. |
 | MicroM.Database | Documentation not started. |
 | MicroM.Excel | Documentation not started. |
 | MicroM.Extensions | Documentation not started. |


### PR DESCRIPTION
## Summary
- document `MicroM.DataDictionary.StatusDefs` namespace with class overview
- link StatusDefs namespace in backend docs index
- mark StatusDefs docs as incomplete in progress tracker

## Testing
- `dotnet test` *(fails: /usr/bin/sh: ... del: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78a305058832482755104e09ba17b