### PR TITLE
Add MicroM.Excel namespace documentation

### DIFF
--- a/MicroM/Documentation-Progress/Backend/docs-state-backend.md
+++ b/MicroM/Documentation-Progress/Backend/docs-state-backend.md
@@ -47,8 +47,8 @@ This file tracks the current documentation state of the backend (`/MicroM/core`)
 - Notes: Namespace and classes documented; XML comments pending.
 
 ### MicroM.Excel
-- State: Not Started ❌
-- Notes: No documentation present.
+- State: Incomplete ⚠️
+- Notes: Namespace and classes documented; XML comments pending.
 
 ### MicroM.Extensions
 - State: Not Started ❌

--- a/MicroM/Documentation-Progress/Backend/iteration-summary.md
+++ b/MicroM/Documentation-Progress/Backend/iteration-summary.md
@@ -261,3 +261,25 @@
 ### Next iteration Tasks
 - Document remaining MicromUsers classes (e.g., `MicromUsers`, `MicromUsersDevices`).
 - Continue expanding `MicroM.DataDictionary` entities documentation.
+
+## Iteration 9
+### Plan
+- Document `MicroM.Excel` namespace and its types.
+- Link namespace from root backend index.
+- Update `docs-state-backend.md` for `MicroM.Excel`.
+
+### Execution Results
+- Created namespace and class docs for `MicroM.Excel` → ✅ Success
+- Updated root backend index with `MicroM.Excel` entry → ✅ Success
+- Updated `docs-state-backend.md` marking `MicroM.Excel` as Incomplete → ✅ Success
+
+### Verification Results
+- `MicroM/Documentation/Backend/MicroM.Excel/index.md` lists classes and links correctly → ✅ Success
+- Root index links to `MicroM.Excel` namespace → ✅ Success
+- Progress file shows `MicroM.Excel` as Incomplete → ✅ Success
+
+### Issues Encountered
+- Public methods in `MicroM.Excel` lack XML comments.
+
+### Next iteration Tasks
+- Add XML comments to `DataResultExcelExtensions` and `ExcelReader`.

--- a/MicroM/Documentation/Backend/MicroM.Excel/DataResultExcelExtensions/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Excel/DataResultExcelExtensions/index.md
@@ -1,0 +1,24 @@
+# Class: MicroM.Excel.DataResultExcelExtensions
+## Overview
+Provides an extension method to save a DataResult as an Excel worksheet.
+
+**Inheritance**
+object -> DataResultExcelExtensions
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+await dataResult.SaveAsExcelToStreamAsync(stream, "Sheet1");
+```
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| SaveAsExcelToStreamAsync(DataResult data, Stream outputStream, string sheetName) | Writes the DataResult to the provided stream in Excel format. |
+
+## Remarks
+None.
+
+## See Also
+- [ExcelReader](../ExcelReader/index.md)

--- a/MicroM/Documentation/Backend/MicroM.Excel/ExcelReader/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Excel/ExcelReader/index.md
@@ -1,0 +1,27 @@
+# Class: MicroM.Excel.ExcelReader
+## Overview
+Provides utilities to read Excel spreadsheets asynchronously.
+
+**Inheritance**
+object -> ExcelReader
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+await foreach (var row in ExcelReader.ReadExcelAsync(stream, null))
+{
+    // Process row data
+}
+```
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| ReadExcelAsync(Stream stream, string? sheetName, int initialRow = 1) | Reads an Excel stream and yields rows starting from the specified row. |
+
+## Remarks
+None.
+
+## See Also
+- [DataResultExcelExtensions](../DataResultExcelExtensions/index.md)

--- a/MicroM/Documentation/Backend/MicroM.Excel/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Excel/index.md
@@ -1,0 +1,15 @@
+# Namespace: MicroM.Excel
+## Overview
+Excel input and output helpers for MicroM.
+
+## Classes
+| Class | Description |
+|:------------|:-------------|
+| [DataResultExcelExtensions](DataResultExcelExtensions/index.md) | Extensions for exporting DataResult to Excel streams. |
+| [ExcelReader](ExcelReader/index.md) | Reads Excel files and yields row data. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/index.md
+++ b/MicroM/Documentation/Backend/index.md
@@ -1,4 +1,4 @@
-# MicroM Backend Documentation
+| [MicroM.Excel](MicroM.Excel/index.md) | Excel input and output helpers. |# MicroM Backend Documentation
 
 This section provides documentation for the MicroM backend namespaces.
 
@@ -15,7 +15,7 @@ This section provides documentation for the MicroM backend namespaces.
 | [MicroM.DataDictionary.Entities.MicromUsers](MicroM.DataDictionary.Entities.MicromUsers/index.md) | Authentication-related entity helpers and results. |
 | [MicroM.DataDictionary.StatusDefs](MicroM.DataDictionary.StatusDefs/index.md) | Status definitions for emails, file uploads, imports, and processes. |
 | [MicroM.Database](MicroM.Database/index.md) | Database utilities and schema management. |
-| MicroM.Excel | Documentation not started. |
+| [MicroM.Excel](MicroM.Excel/index.md) | Excel input and output helpers. |
 | MicroM.Extensions | Documentation not started. |
 | MicroM.Generators | Documentation not started. |
 | MicroM.Generators.Extensions | Documentation not started. |


### PR DESCRIPTION
## Summary
- document MicroM.Excel namespace and its classes
- link MicroM.Excel from backend index
- update progress files for new namespace

## Testing
- `dotnet test MicroM.sln` *(fails: del: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a89c5ce9088324ad8415aee0fd5533