### PR TITLE
docs: document generator namespaces

### DIFF
--- a/MicroM/Documentation-Progress/Backend/docs-state-backend.md
+++ b/MicroM/Documentation-Progress/Backend/docs-state-backend.md
@@ -55,20 +55,20 @@ This file tracks the current documentation state of the backend (`/MicroM/core`)
 - Notes: No documentation present.
 
 ### MicroM.Generators
-- State: Not Started ❌
-- Notes: No documentation present.
+- State: Complete ✅
+- Notes: Namespace and public types documented.
 
 ### MicroM.Generators.Extensions
-- State: Not Started ❌
-- Notes: No documentation present.
+- State: Complete ✅
+- Notes: Namespace and public types documented.
 
 ### MicroM.Generators.ReactGenerator
-- State: Not Started ❌
-- Notes: No documentation present.
+- State: Complete ✅
+- Notes: Namespace and public types documented.
 
 ### MicroM.Generators.SQLGenerator
-- State: Not Started ❌
-- Notes: No documentation present.
+- State: Complete ✅
+- Notes: Namespace and public types documented.
 
 ### MicroM.ImportData
 - State: Not Started ❌

--- a/MicroM/Documentation-Progress/Backend/iteration-summary.md
+++ b/MicroM/Documentation-Progress/Backend/iteration-summary.md
@@ -261,3 +261,28 @@
 ### Next iteration Tasks
 - Document remaining MicromUsers classes (e.g., `MicromUsers`, `MicromUsersDevices`).
 - Continue expanding `MicroM.DataDictionary` entities documentation.
+
+## Iteration 9
+### Plan
+- Document generator namespaces:
+  - `MicroM.Generators`
+  - `MicroM.Generators.Extensions`
+  - `MicroM.Generators.ReactGenerator`
+  - `MicroM.Generators.SQLGenerator`
+- Update root documentation index and `docs-state-backend.md`.
+
+### Execution Results
+- Added namespace and type docs for all generator namespaces → ✅ Success
+- Updated root documentation index with links → ✅ Success
+- Updated `docs-state-backend.md` with completion status → ✅ Success
+
+### Verification Results
+- Confirmed namespace indexes list all public types → ✅ Success
+- Root `index.md` links to new namespaces → ✅ Success
+- `docs-state-backend.md` marks generator namespaces as Complete → ✅ Success
+
+### Issues Encountered
+- None.
+
+### Next iteration Tasks
+- Begin documenting `MicroM.Excel` namespace.

--- a/MicroM/Documentation/Backend/MicroM.Generators.Extensions/CommonExtensions/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Generators.Extensions/CommonExtensions/index.md
@@ -1,0 +1,25 @@
+# Class: MicroM.Generators.Extensions.CommonExtensions
+## Overview
+String extension methods used by MicroM generators.
+
+**Inheritance**
+object -> CommonExtensions
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+string formatted = "MyValue".RemoveEmptyLines();
+```
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| RemoveEmptyLines(this string) | Collapses repeated blank lines into a single line. |
+| AddSpacesAndLowercaseShortWords(this string?) | Inserts spaces before capitals and lowercases short words. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Generators.Extensions/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Generators.Extensions/index.md
@@ -1,0 +1,14 @@
+# Namespace: MicroM.Generators.Extensions
+## Overview
+Extension methods supporting generator utilities.
+
+## Classes
+| Class | Description |
+|:------------|:-------------|
+| [CommonExtensions](CommonExtensions/index.md) | String helpers for generator templates. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Generators.ReactGenerator/CategoriesExtensions/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Generators.ReactGenerator/CategoriesExtensions/index.md
@@ -1,0 +1,26 @@
+# Class: MicroM.Generators.ReactGenerator.CategoriesExtensions
+## Overview
+Generates TypeScript code for category relationships.
+
+**Inheritance**
+object -> CategoriesExtensions
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+string lookup = columns.AsLookupDefinitionContentCategories();
+```
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| AsLookupDefinitionContentCategories(this IReadonlyOrderedDictionary<ColumnBase>, string) | Builds lookup definition block for related categories. |
+| AsEmbeddedCategoriesImport(this IReadonlyOrderedDictionary<ColumnBase>) | Lists category entities to import. |
+| AsCategoriesEntities(this IReadonlyOrderedDictionary<ColumnBase>, Dictionary<string, Type>) | Generates TypeScript classes for related categories. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Generators.ReactGenerator/ColumnExtensions/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Generators.ReactGenerator/ColumnExtensions/index.md
@@ -1,0 +1,24 @@
+# Class: MicroM.Generators.ReactGenerator.ColumnExtensions
+## Overview
+Converts column metadata into TypeScript-friendly values.
+
+**Inheritance**
+object -> ColumnExtensions
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+string display = column.AsDisplayName();
+```
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| AsDisplayName(this ColumnBase) | Produces a human-readable title for a column. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Generators.ReactGenerator/EntityExtensions/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Generators.ReactGenerator/EntityExtensions/index.md
@@ -1,0 +1,26 @@
+# Class: MicroM.Generators.ReactGenerator.EntityExtensions
+## Overview
+Creates TypeScript entity definitions, classes, and forms.
+
+**Inheritance**
+object -> EntityExtensions
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+string def = entity.AsTypeScriptEntityDefinition();
+```
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| AsTypeScriptEntityDefinition<T>(this T) where T : EntityBase | Builds a TypeScript entity definition file. |
+| AsTypeScriptEntity<T>(this T) where T : EntityBase | Generates a TypeScript entity class. |
+| AsTypeScriptEntityForm<T>(this T) where T : EntityBase | Creates a TypeScript form component for the entity. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Generators.ReactGenerator/LookupExtensions/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Generators.ReactGenerator/LookupExtensions/index.md
@@ -1,0 +1,26 @@
+# Class: MicroM.Generators.ReactGenerator.LookupExtensions
+## Overview
+Builds lookup definition sections for TypeScript entities.
+
+**Inheritance**
+object -> LookupExtensions
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+string lookup = entity.Def.AsLookupDefinition();
+```
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| AsDefaultLookupDefinitionContent(this IReadOnlyDictionary<string, EntityForeignKeyBase>, string) | Generates default lookup mappings. |
+| AsLookupDefinitionContent(this IReadOnlyDictionary<string, EntityForeignKeyBase>, string) | Creates lookup mappings for foreign keys. |
+| AsLookupDefinition(this EntityDefinition, string) | Builds the complete lookup definition block. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Generators.ReactGenerator/ProcsExtensions/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Generators.ReactGenerator/ProcsExtensions/index.md
@@ -1,0 +1,24 @@
+# Class: MicroM.Generators.ReactGenerator.ProcsExtensions
+## Overview
+Creates TypeScript procedure definition blocks for entities.
+
+**Inheritance**
+object -> ProcsExtensions
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+string procs = def.AsProcsDefinition();
+```
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| AsProcsDefinition(this EntityDefinition, string) | Generates procedure definitions for entity operations. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Generators.ReactGenerator/ViewExtensions/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Generators.ReactGenerator/ViewExtensions/index.md
@@ -1,0 +1,24 @@
+# Class: MicroM.Generators.ReactGenerator.ViewExtensions
+## Overview
+Generates TypeScript view definitions from entity metadata.
+
+**Inheritance**
+object -> ViewExtensions
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+string views = entity.Def.Views.AsViewsDefinition();
+```
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| AsViewsDefinition(this IReadOnlyDictionary<string, ViewDefinition>, string) | Produces view mapping objects for a TypeScript entity. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Generators.ReactGenerator/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Generators.ReactGenerator/index.md
@@ -1,0 +1,19 @@
+# Namespace: MicroM.Generators.ReactGenerator
+## Overview
+Helpers for generating React client TypeScript code.
+
+## Classes
+| Class | Description |
+|:------------|:-------------|
+| [CategoriesExtensions](CategoriesExtensions/index.md) | Generates category-related TypeScript fragments. |
+| [ColumnExtensions](ColumnExtensions/index.md) | Converts column metadata into TypeScript structures. |
+| [EntityExtensions](EntityExtensions/index.md) | Builds TypeScript entity classes and forms. |
+| [LookupExtensions](LookupExtensions/index.md) | Creates lookup definitions for TypeScript entities. |
+| [ProcsExtensions](ProcsExtensions/index.md) | Produces procedure definitions for entities. |
+| [ViewExtensions](ViewExtensions/index.md) | Produces view definition code for entities. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Generators.SQLGenerator/TableExtensions/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Generators.SQLGenerator/TableExtensions/index.md
@@ -1,0 +1,35 @@
+# Class: MicroM.Generators.SQLGenerator.TableExtensions
+## Overview
+Extension methods for generating database tables and related scripts.
+
+**Inheritance**
+object -> TableExtensions
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+List<string> scripts = entity.AsCreateTable();
+```
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| IsTableCreated<T>(this T, DatabaseClient, CancellationToken) where T : EntityBase | Checks if an entity table exists. |
+| AsCreateTable<T>(this T, bool, bool) where T : EntityBase | Produces SQL to create a table and indexes. |
+| AsDropIndexes<T>(this T) where T : EntityBase | Generates SQL to drop existing indexes. |
+| AsCreateIndexes<T>(this T) where T : EntityBase | Generates SQL to create indexes. |
+| AsDropUniqueConstraints<T>(this T) where T : EntityBase | Generates SQL to drop unique constraints. |
+| AsAlterUniqueConstraints<T>(this T) where T : EntityBase | Generates SQL to recreate unique constraints. |
+| AsDropPrimaryKey<T>(this T) where T : EntityBase | Generates SQL to drop the primary key. |
+| AsAlterPrimaryKey<T>(this T) where T : EntityBase | Generates SQL to recreate the primary key. |
+| AsDropForeignKeys<T>(this T) where T : EntityBase | Generates SQL to drop foreign keys. |
+| AsCreateForeignKeysIndexes<T>(this T) where T : EntityBase | Generates SQL to create foreign key indexes. |
+| AsAlterForeignKeys<T>(this T, bool) where T : EntityBase | Generates SQL to recreate foreign keys. |
+| AsGrantExecutionToEntityProcsScript<T>(this T, string) where T : EntityBase | Builds grant scripts for entity stored procedures. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Generators.SQLGenerator/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Generators.SQLGenerator/index.md
@@ -1,0 +1,14 @@
+# Namespace: MicroM.Generators.SQLGenerator
+## Overview
+Helpers for generating SQL scripts and schema definitions.
+
+## Classes
+| Class | Description |
+|:------------|:-------------|
+| [TableExtensions](TableExtensions/index.md) | Generates SQL DDL and management scripts for entities. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Generators/Constants/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Generators/Constants/index.md
@@ -1,0 +1,24 @@
+# Class: MicroM.Generators.Constants
+## Overview
+Provides constant values for MicroM generator utilities.
+
+**Inheritance**
+object -> Constants
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+var indent = MicroM.Generators.Constants.TAB;
+```
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| TAB | string | Four-space indentation token. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Generators/GeneratorsRegex/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Generators/GeneratorsRegex/index.md
@@ -1,0 +1,25 @@
+# Class: MicroM.Generators.GeneratorsRegex
+## Overview
+Provides precompiled regular expressions used by generator helpers.
+
+**Inheritance**
+object -> GeneratorsRegex
+
+**Implements**
+None
+
+## Example Usage
+```csharp
+var regex = MicroM.Generators.GeneratorsRegex.MultipleEmptyLines();
+```
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| MultipleEmptyLines() | Matches repeated empty lines in text. |
+| SplitCamelCaseWords() | Splits camel case identifiers into separate words. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Generators/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Generators/index.md
@@ -1,0 +1,15 @@
+# Namespace: MicroM.Generators
+## Overview
+Utilities for building MicroM code generators.
+
+## Classes
+| Class | Description |
+|:------------|:-------------|
+| [Constants](Constants/index.md) | Shared constant values used by generators. |
+| [GeneratorsRegex](GeneratorsRegex/index.md) | Precompiled regular expressions for generator helpers. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/index.md
+++ b/MicroM/Documentation/Backend/index.md
@@ -17,10 +17,10 @@ This section provides documentation for the MicroM backend namespaces.
 | [MicroM.Database](MicroM.Database/index.md) | Database utilities and schema management. |
 | MicroM.Excel | Documentation not started. |
 | MicroM.Extensions | Documentation not started. |
-| MicroM.Generators | Documentation not started. |
-| MicroM.Generators.Extensions | Documentation not started. |
-| MicroM.Generators.ReactGenerator | Documentation not started. |
-| MicroM.Generators.SQLGenerator | Documentation not started. |
+| [MicroM.Generators](MicroM.Generators/index.md) | Utilities for building code generators. |
+| [MicroM.Generators.Extensions](MicroM.Generators.Extensions/index.md) | Extension helpers for generators. |
+| [MicroM.Generators.ReactGenerator](MicroM.Generators.ReactGenerator/index.md) | Generates React TypeScript code for entities. |
+| [MicroM.Generators.SQLGenerator](MicroM.Generators.SQLGenerator/index.md) | Generates SQL DDL and related scripts. |
 | MicroM.ImportData | Documentation not started. |
 | MicroM.Validators | Documentation not started. |
 | MicroM.Web | Documentation not started. |


### PR DESCRIPTION
## Summary
- add namespace docs for MicroM.Generators and sub-namespaces
- document generator classes and extension helpers
- update backend index and documentation status

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: del command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a89c629e7c8324a704931e3635f74c