### PR TITLE
docs: add web namespace documentation

### DIFF
--- a/MicroM/Documentation-Progress/Backend/docs-state-backend.md
+++ b/MicroM/Documentation-Progress/Backend/docs-state-backend.md
@@ -79,36 +79,36 @@ This file tracks the current documentation state of the backend (`/MicroM/core`)
 - Notes: No documentation present.
 
 ### MicroM.Web
-- State: Not Started ❌
-- Notes: No documentation present.
+- State: Incomplete ⚠️
+- Notes: Namespace index created; sub-namespaces documented.
 
 ### MicroM.Web.Authentication
-- State: Not Started ❌
-- Notes: No documentation present.
+- State: Incomplete ⚠️
+- Notes: Namespace and types documented; XML comments pending.
 
 ### MicroM.Web.Authentication.SSO
-- State: Not Started ❌
-- Notes: No documentation present.
+- State: Incomplete ⚠️
+- Notes: Namespace index and interface documentation added.
 
 ### MicroM.Web.Controllers
-- State: Not Started ❌
-- Notes: No documentation present.
+- State: Incomplete ⚠️
+- Notes: Controllers and interfaces documented; method details pending.
 
 ### MicroM.Web.Debug
-- State: Not Started ❌
-- Notes: No documentation present.
+- State: Incomplete ⚠️
+- Notes: Debug utilities documented; additional details needed.
 
 ### MicroM.Web.Middleware
-- State: Not Started ❌
-- Notes: No documentation present.
+- State: Incomplete ⚠️
+- Notes: Middleware documented; review XML comments.
 
 ### MicroM.Web.Services
-- State: Not Started ❌
-- Notes: No documentation present.
+- State: Incomplete ⚠️
+- Notes: Service classes documented; XML comments and examples missing.
 
 ### MicroM.Web.Services.Security
-- State: Not Started ❌
-- Notes: No documentation present.
+- State: Incomplete ⚠️
+- Notes: Security components documented; further refinement required.
 
 ## Tutorials
 - Overview tutorial: Not Started ❌

--- a/MicroM/Documentation-Progress/Backend/iteration-summary.md
+++ b/MicroM/Documentation-Progress/Backend/iteration-summary.md
@@ -331,3 +331,29 @@
 ### Next iteration Tasks
 - Add XML comments to all `MicroM.Extensions` classes and methods.
 - Add XML comments to `DataResultExcelExtensions` and `ExcelReader`.
+
+---
+
+## Iteration 12
+### Plan
+- Document web namespaces and public types:
+  - Create namespace indexes for `MicroM.Web` and sub-namespaces.
+  - Add class and interface docs for controllers, services, middleware, and security components.
+- Link web namespaces from `MicroM/Documentation/Backend/index.md`.
+- Update `docs-state-backend.md` for new documentation coverage.
+
+### Execution Results
+- Added namespace and type docs under `MicroM/Documentation/Backend/MicroM.Web*` → ✅ Success
+- Updated root backend index with links to web namespaces → ✅ Success
+- Updated documentation state for web namespaces → ✅ Success
+
+### Verification Results
+- Verified namespace indexes list documented types and are linked from parent index → ✅ Success
+- Confirmed `docs-state-backend.md` reflects new coverage → ✅ Success
+
+### Issues Encountered
+- XML comments for many web types are still missing.
+
+### Next iteration Tasks
+- Add XML comments for web services and controllers.
+- Expand documentation with method details and examples.

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication.SSO/IIdentityProviderService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication.SSO/IIdentityProviderService/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Authentication.SSO.IIdentityProviderService
+## Overview
+Defines the contract for identity provider service.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication.SSO/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication.SSO/index.md
@@ -1,0 +1,14 @@
+# Namespace: MicroM.Web.Authentication.SSO
+## Overview
+Single sign-on authentication helpers.
+
+## Interfaces
+| Interface | Description |
+|:------------|:-------------|
+| [IIdentityProviderService](IIdentityProviderService/index.md) | Interface for identity provider service. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/AccountLockout/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/AccountLockout/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.AccountLockout
+## Overview
+Account Lockout class.
+
+**Inheritance**
+object -> AccountLockout
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/AuthenticatorResult/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/AuthenticatorResult/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.AuthenticatorResult
+## Overview
+Authenticator Result class.
+
+**Inheritance**
+object -> AuthenticatorResult
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/BrowserDeviceIDService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/BrowserDeviceIDService/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.BrowserDeviceIDService
+## Overview
+Browser Device I D Service class.
+
+**Inheritance**
+object -> BrowserDeviceIDService
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/IAuthenticationProvider/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/IAuthenticationProvider/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Authentication.IAuthenticationProvider
+## Overview
+Defines the contract for authentication provider.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/IAuthenticator/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/IAuthenticator/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Authentication.IAuthenticator
+## Overview
+Defines the contract for authenticator.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/IDeviceIdService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/IDeviceIdService/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Authentication.IDeviceIdService
+## Overview
+Defines the contract for device id service.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/MicroMAuthenticationProvider/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/MicroMAuthenticationProvider/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.MicroMAuthenticationProvider
+## Overview
+Micro M Authentication Provider class.
+
+**Inheritance**
+object -> MicroMAuthenticationProvider
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/MicroMAuthenticator/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/MicroMAuthenticator/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.MicroMAuthenticator
+## Overview
+Micro M Authenticator class.
+
+**Inheritance**
+object -> MicroMAuthenticator
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/MicroMClientClaimTypes/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/MicroMClientClaimTypes/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.MicroMClientClaimTypes
+## Overview
+Micro M Client Claim Types class.
+
+**Inheritance**
+object -> MicroMClientClaimTypes
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/MicroMCorsPolicyProvider/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/MicroMCorsPolicyProvider/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.MicroMCorsPolicyProvider
+## Overview
+Micro M Cors Policy Provider class.
+
+**Inheritance**
+object -> MicroMCorsPolicyProvider
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/MicroMServerClaimTypes/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/MicroMServerClaimTypes/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.MicroMServerClaimTypes
+## Overview
+Micro M Server Claim Types class.
+
+**Inheritance**
+object -> MicroMServerClaimTypes
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/SQLServerAuthenticator/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/SQLServerAuthenticator/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.SQLServerAuthenticator
+## Overview
+S Q L Server Authenticator class.
+
+**Inheritance**
+object -> SQLServerAuthenticator
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/TokenResult/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/TokenResult/index.md
@@ -1,0 +1,15 @@
+# Record: MicroM.Web.Authentication.TokenResult
+## Overview
+Token Result record.
+
+**Inheritance**
+object -> TokenResult
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/UserLogin/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/UserLogin/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.UserLogin
+## Overview
+User Login class.
+
+**Inheritance**
+object -> UserLogin
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/UserPasswordHasher/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/UserPasswordHasher/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.UserPasswordHasher
+## Overview
+User Password Hasher class.
+
+**Inheritance**
+object -> UserPasswordHasher
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/UserRecoverPassword/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/UserRecoverPassword/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.UserRecoverPassword
+## Overview
+User Recover Password class.
+
+**Inheritance**
+object -> UserRecoverPassword
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/UserRecoveryEmail/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/UserRecoveryEmail/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.UserRecoveryEmail
+## Overview
+User Recovery Email class.
+
+**Inheritance**
+object -> UserRecoveryEmail
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/UserRefreshTokenRequest/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/UserRefreshTokenRequest/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.UserRefreshTokenRequest
+## Overview
+User Refresh Token Request class.
+
+**Inheritance**
+object -> UserRefreshTokenRequest
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/WebAPIJsonWebTokenHandler/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/WebAPIJsonWebTokenHandler/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.WebAPIJsonWebTokenHandler
+## Overview
+Web A P I Json Web Token Handler class.
+
+**Inheritance**
+object -> WebAPIJsonWebTokenHandler
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/WebAPIJwtPostConfigurationOptions/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/WebAPIJwtPostConfigurationOptions/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Authentication.WebAPIJwtPostConfigurationOptions
+## Overview
+Web A P I Jwt Post Configuration Options class.
+
+**Inheritance**
+object -> WebAPIJwtPostConfigurationOptions
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/index.md
@@ -1,0 +1,37 @@
+# Namespace: MicroM.Web.Authentication
+## Overview
+Authentication utilities for web apps.
+
+## Classes
+| Class | Description |
+|:------------|:-------------|
+| [BrowserDeviceIDService](BrowserDeviceIDService/index.md) | Browser Device I D Service class. |
+| [MicroMCorsPolicyProvider](MicroMCorsPolicyProvider/index.md) | Micro M Cors Policy Provider class. |
+| [UserPasswordHasher](UserPasswordHasher/index.md) | User Password Hasher class. |
+| [UserRecoveryEmail](UserRecoveryEmail/index.md) | User Recovery Email class. |
+| [UserRecoverPassword](UserRecoverPassword/index.md) | User Recover Password class. |
+| [MicroMAuthenticator](MicroMAuthenticator/index.md) | Micro M Authenticator class. |
+| [AccountLockout](AccountLockout/index.md) | Account Lockout class. |
+| [SQLServerAuthenticator](SQLServerAuthenticator/index.md) | S Q L Server Authenticator class. |
+| [MicroMClientClaimTypes](MicroMClientClaimTypes/index.md) | Micro M Client Claim Types class. |
+| [MicroMServerClaimTypes](MicroMServerClaimTypes/index.md) | Micro M Server Claim Types class. |
+| [WebAPIJwtPostConfigurationOptions](WebAPIJwtPostConfigurationOptions/index.md) | Web A P I Jwt Post Configuration Options class. |
+| [TokenResult](TokenResult/index.md) | Token Result class. |
+| [WebAPIJsonWebTokenHandler](WebAPIJsonWebTokenHandler/index.md) | Web A P I Json Web Token Handler class. |
+| [UserLogin](UserLogin/index.md) | User Login class. |
+| [MicroMAuthenticationProvider](MicroMAuthenticationProvider/index.md) | Micro M Authentication Provider class. |
+| [AuthenticatorResult](AuthenticatorResult/index.md) | Authenticator Result class. |
+| [UserRefreshTokenRequest](UserRefreshTokenRequest/index.md) | User Refresh Token Request class. |
+
+## Interfaces
+| Interface | Description |
+|:------------|:-------------|
+| [IDeviceIdService](IDeviceIdService/index.md) | Interface for device id service. |
+| [IAuthenticationProvider](IAuthenticationProvider/index.md) | Interface for authentication provider. |
+| [IAuthenticator](IAuthenticator/index.md) | Interface for authenticator. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Controllers/AuthenticationController/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Controllers/AuthenticationController/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Controllers.AuthenticationController
+## Overview
+Authentication Controller class.
+
+**Inheritance**
+object -> AuthenticationController
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Controllers/EntitiesController/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Controllers/EntitiesController/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Controllers.EntitiesController
+## Overview
+Entities Controller class.
+
+**Inheritance**
+object -> EntitiesController
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Controllers/FileController/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Controllers/FileController/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Controllers.FileController
+## Overview
+File Controller class.
+
+**Inheritance**
+object -> FileController
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Controllers/IAuthenticationController/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Controllers/IAuthenticationController/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Controllers.IAuthenticationController
+## Overview
+Defines the contract for authentication controller.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Controllers/IEntitiesController/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Controllers/IEntitiesController/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Controllers.IEntitiesController
+## Overview
+Defines the contract for entities controller.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Controllers/IFileController/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Controllers/IFileController/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Controllers.IFileController
+## Overview
+Defines the contract for file controller.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Controllers/IIdentityProviderClientController/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Controllers/IIdentityProviderClientController/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Controllers.IIdentityProviderClientController
+## Overview
+Defines the contract for identity provider client controller.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Controllers/IIdentityProviderController/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Controllers/IIdentityProviderController/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Controllers.IIdentityProviderController
+## Overview
+Defines the contract for identity provider controller.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Controllers/IPublicController/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Controllers/IPublicController/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Controllers.IPublicController
+## Overview
+Defines the contract for public controller.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Controllers/IdentityProviderController/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Controllers/IdentityProviderController/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Controllers.IdentityProviderController
+## Overview
+Identity Provider Controller class.
+
+**Inheritance**
+object -> IdentityProviderController
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Controllers/MicroMControllersMessages/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Controllers/MicroMControllersMessages/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Controllers.MicroMControllersMessages
+## Overview
+Micro M Controllers Messages class.
+
+**Inheritance**
+object -> MicroMControllersMessages
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Controllers/MicroMRouteConvention/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Controllers/MicroMRouteConvention/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Controllers.MicroMRouteConvention
+## Overview
+Micro M Route Convention class.
+
+**Inheritance**
+object -> MicroMRouteConvention
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Controllers/MicroMRouteConventionSetup/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Controllers/MicroMRouteConventionSetup/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Controllers.MicroMRouteConventionSetup
+## Overview
+Micro M Route Convention Setup class.
+
+**Inheritance**
+object -> MicroMRouteConventionSetup
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Controllers/PublicController/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Controllers/PublicController/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Controllers.PublicController
+## Overview
+Public Controller class.
+
+**Inheritance**
+object -> PublicController
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Controllers/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Controllers/index.md
@@ -1,0 +1,31 @@
+# Namespace: MicroM.Web.Controllers
+## Overview
+ASP.NET Core controllers for MicroM.
+
+## Classes
+| Class | Description |
+|:------------|:-------------|
+| [MicroMControllersMessages](MicroMControllersMessages/index.md) | Micro M Controllers Messages class. |
+| [EntitiesController](EntitiesController/index.md) | Entities Controller class. |
+| [MicroMRouteConvention](MicroMRouteConvention/index.md) | Micro M Route Convention class. |
+| [MicroMRouteConventionSetup](MicroMRouteConventionSetup/index.md) | Micro M Route Convention Setup class. |
+| [AuthenticationController](AuthenticationController/index.md) | Authentication Controller class. |
+| [IdentityProviderController](IdentityProviderController/index.md) | Identity Provider Controller class. |
+| [PublicController](PublicController/index.md) | Public Controller class. |
+| [FileController](FileController/index.md) | File Controller class. |
+
+## Interfaces
+| Interface | Description |
+|:------------|:-------------|
+| [IEntitiesController](IEntitiesController/index.md) | Interface for entities controller. |
+| [IIdentityProviderClientController](IIdentityProviderClientController/index.md) | Interface for identity provider client controller. |
+| [IAuthenticationController](IAuthenticationController/index.md) | Interface for authentication controller. |
+| [IIdentityProviderController](IIdentityProviderController/index.md) | Interface for identity provider controller. |
+| [IPublicController](IPublicController/index.md) | Interface for public controller. |
+| [IFileController](IFileController/index.md) | Interface for file controller. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Debug/DependencyInjectionDebug/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Debug/DependencyInjectionDebug/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Debug.DependencyInjectionDebug
+## Overview
+Dependency Injection Debug class.
+
+**Inheritance**
+object -> DependencyInjectionDebug
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Debug/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Debug/index.md
@@ -1,0 +1,14 @@
+# Namespace: MicroM.Web.Debug
+## Overview
+Debugging utilities for web applications.
+
+## Classes
+| Class | Description |
+|:------------|:-------------|
+| [DependencyInjectionDebug](DependencyInjectionDebug/index.md) | Dependency Injection Debug class. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Middleware/DebugRoutesMiddleware/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Middleware/DebugRoutesMiddleware/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Middleware.DebugRoutesMiddleware
+## Overview
+Debug Routes Middleware class.
+
+**Inheritance**
+object -> DebugRoutesMiddleware
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Middleware/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Middleware/index.md
@@ -1,0 +1,14 @@
+# Namespace: MicroM.Web.Middleware
+## Overview
+Middleware components for request handling.
+
+## Classes
+| Class | Description |
+|:------------|:-------------|
+| [DebugRoutesMiddleware](DebugRoutesMiddleware/index.md) | Debug Routes Middleware class. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services.Security/EveryoneAllowedRoutes/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services.Security/EveryoneAllowedRoutes/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.Security.EveryoneAllowedRoutes
+## Overview
+Everyone Allowed Routes class.
+
+**Inheritance**
+object -> EveryoneAllowedRoutes
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services.Security/GetAllGroupsAllowedRoutesResult/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services.Security/GetAllGroupsAllowedRoutesResult/index.md
@@ -1,0 +1,15 @@
+# Record: MicroM.Web.Services.Security.GetAllGroupsAllowedRoutesResult
+## Overview
+Get All Groups Allowed Routes Result record.
+
+**Inheritance**
+object -> GetAllGroupsAllowedRoutesResult
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services.Security/GroupSecurityRecord/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services.Security/GroupSecurityRecord/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.Security.GroupSecurityRecord
+## Overview
+Group Security Record class.
+
+**Inheritance**
+object -> GroupSecurityRecord
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services.Security/ISecurityService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services.Security/ISecurityService/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Services.Security.ISecurityService
+## Overview
+Defines the contract for security service.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services.Security/MicroMEveryoneAllowedRoutes/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services.Security/MicroMEveryoneAllowedRoutes/index.md
@@ -1,0 +1,9 @@
+# Enum: MicroM.Web.Services.Security.MicroMEveryoneAllowedRoutes
+## Overview
+Micro M Everyone Allowed Routes enum.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services.Security/MicroMPermissionsConstants/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services.Security/MicroMPermissionsConstants/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.Security.MicroMPermissionsConstants
+## Overview
+Micro M Permissions Constants class.
+
+**Inheritance**
+object -> MicroMPermissionsConstants
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services.Security/MicroMPermissionsHandler/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services.Security/MicroMPermissionsHandler/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.Security.MicroMPermissionsHandler
+## Overview
+Micro M Permissions Handler class.
+
+**Inheritance**
+object -> MicroMPermissionsHandler
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services.Security/MicroMPermissionsRequirement/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services.Security/MicroMPermissionsRequirement/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.Security.MicroMPermissionsRequirement
+## Overview
+Micro M Permissions Requirement class.
+
+**Inheritance**
+object -> MicroMPermissionsRequirement
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services.Security/PublicEndpointAttribute/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services.Security/PublicEndpointAttribute/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.Security.PublicEndpointAttribute
+## Overview
+Public Endpoint Attribute class.
+
+**Inheritance**
+object -> PublicEndpointAttribute
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services.Security/PublicEndpointSecurityRecord/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services.Security/PublicEndpointSecurityRecord/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.Security.PublicEndpointSecurityRecord
+## Overview
+Public Endpoint Security Record class.
+
+**Inheritance**
+object -> PublicEndpointSecurityRecord
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services.Security/PublicEndpointsMiddleware/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services.Security/PublicEndpointsMiddleware/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.Security.PublicEndpointsMiddleware
+## Overview
+Public Endpoints Middleware class.
+
+**Inheritance**
+object -> PublicEndpointsMiddleware
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services.Security/SecurityService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services.Security/SecurityService/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.Security.SecurityService
+## Overview
+Security Service class.
+
+**Inheritance**
+object -> SecurityService
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services.Security/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services.Security/index.md
@@ -1,0 +1,33 @@
+# Namespace: MicroM.Web.Services.Security
+## Overview
+Security-related web services.
+
+## Classes
+| Class | Description |
+|:------------|:-------------|
+| [GetAllGroupsAllowedRoutesResult](GetAllGroupsAllowedRoutesResult/index.md) | Get All Groups Allowed Routes Result class. |
+| [SecurityService](SecurityService/index.md) | Security Service class. |
+| [PublicEndpointsMiddleware](PublicEndpointsMiddleware/index.md) | Public Endpoints Middleware class. |
+| [PublicEndpointSecurityRecord](PublicEndpointSecurityRecord/index.md) | Public Endpoint Security Record class. |
+| [PublicEndpointAttribute](PublicEndpointAttribute/index.md) | Public Endpoint Attribute class. |
+| [GroupSecurityRecord](GroupSecurityRecord/index.md) | Group Security Record class. |
+| [EveryoneAllowedRoutes](EveryoneAllowedRoutes/index.md) | Everyone Allowed Routes class. |
+| [MicroMPermissionsConstants](MicroMPermissionsConstants/index.md) | Micro M Permissions Constants class. |
+| [MicroMPermissionsRequirement](MicroMPermissionsRequirement/index.md) | Micro M Permissions Requirement class. |
+| [MicroMPermissionsHandler](MicroMPermissionsHandler/index.md) | Micro M Permissions Handler class. |
+
+## Interfaces
+| Interface | Description |
+|:------------|:-------------|
+| [ISecurityService](ISecurityService/index.md) | Interface for security service. |
+
+## Enums
+| Enum | Description |
+|:------------|:-------------|
+| [MicroMEveryoneAllowedRoutes](MicroMEveryoneAllowedRoutes/index.md) | Micro M Everyone Allowed Routes enum. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/AuthenticationService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/AuthenticationService/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.AuthenticationService
+## Overview
+Authentication Service class.
+
+**Inheritance**
+object -> AuthenticationService
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/BackgroundTaskQueue/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/BackgroundTaskQueue/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.BackgroundTaskQueue
+## Overview
+Background Task Queue class.
+
+**Inheritance**
+object -> BackgroundTaskQueue
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/EmailHostedService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/EmailHostedService/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.EmailHostedService
+## Overview
+Email Hosted Service class.
+
+**Inheritance**
+object -> EmailHostedService
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/EmailService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/EmailService/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.EmailService
+## Overview
+Email Service class.
+
+**Inheritance**
+object -> EmailService
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/EmailServiceConfigurationData/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/EmailServiceConfigurationData/index.md
@@ -1,0 +1,15 @@
+# Record: MicroM.Web.Services.EmailServiceConfigurationData
+## Overview
+Email Service Configuration Data record.
+
+**Inheritance**
+object -> EmailServiceConfigurationData
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/EmailServiceDestination/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/EmailServiceDestination/index.md
@@ -1,0 +1,15 @@
+# Record: MicroM.Web.Services.EmailServiceDestination
+## Overview
+Email Service Destination record.
+
+**Inheritance**
+object -> EmailServiceDestination
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/EmailServiceItem/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/EmailServiceItem/index.md
@@ -1,0 +1,15 @@
+# Record: MicroM.Web.Services.EmailServiceItem
+## Overview
+Email Service Item record.
+
+**Inheritance**
+object -> EmailServiceItem
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/EmailServiceTags/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/EmailServiceTags/index.md
@@ -1,0 +1,15 @@
+# Record: MicroM.Web.Services.EmailServiceTags
+## Overview
+Email Service Tags record.
+
+**Inheritance**
+object -> EmailServiceTags
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/EntitiesService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/EntitiesService/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.EntitiesService
+## Overview
+Entities Service class.
+
+**Inheritance**
+object -> EntitiesService
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/FileDetails/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/FileDetails/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.FileDetails
+## Overview
+File Details class.
+
+**Inheritance**
+object -> FileDetails
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/FileUploadService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/FileUploadService/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.FileUploadService
+## Overview
+File Upload Service class.
+
+**Inheritance**
+object -> FileUploadService
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/IAuthenticationService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/IAuthenticationService/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Services.IAuthenticationService
+## Overview
+Defines the contract for authentication service.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/IBackgroundTaskQueue/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/IBackgroundTaskQueue/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Services.IBackgroundTaskQueue
+## Overview
+Defines the contract for background task queue.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/IEmailService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/IEmailService/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Services.IEmailService
+## Overview
+Defines the contract for email service.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/IEntitiesService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/IEntitiesService/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Services.IEntitiesService
+## Overview
+Defines the contract for entities service.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/IFileUploadService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/IFileUploadService/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Services.IFileUploadService
+## Overview
+Defines the contract for file upload service.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/IIdentityProviderService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/IIdentityProviderService/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Services.IIdentityProviderService
+## Overview
+Defines the contract for identity provider service.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/IMemoryQueueHostedService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/IMemoryQueueHostedService/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Services.IMemoryQueueHostedService
+## Overview
+Defines the contract for memory queue hosted service.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/IMicroMAppConfiguration/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/IMicroMAppConfiguration/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Services.IMicroMAppConfiguration
+## Overview
+Defines the contract for micro m app configuration.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/IMicroMEncryption/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/IMicroMEncryption/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Services.IMicroMEncryption
+## Overview
+Defines the contract for micro m encryption.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/IThumbnailService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/IThumbnailService/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Services.IThumbnailService
+## Overview
+Defines the contract for thumbnail service.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/IWebAPIServices/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/IWebAPIServices/index.md
@@ -1,0 +1,9 @@
+# Interface: MicroM.Web.Services.IWebAPIServices
+## Overview
+Defines the contract for web a p i services.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/ImageThumbnailService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/ImageThumbnailService/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.ImageThumbnailService
+## Overview
+Image Thumbnail Service class.
+
+**Inheritance**
+object -> ImageThumbnailService
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/MemoryQueueHostedService/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/MemoryQueueHostedService/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.MemoryQueueHostedService
+## Overview
+Memory Queue Hosted Service class.
+
+**Inheritance**
+object -> MemoryQueueHostedService
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/MicroMAppConfigurationProvider/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/MicroMAppConfigurationProvider/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.MicroMAppConfigurationProvider
+## Overview
+Micro M App Configuration Provider class.
+
+**Inheritance**
+object -> MicroMAppConfigurationProvider
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/MicroMCookieManager/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/MicroMCookieManager/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.MicroMCookieManager
+## Overview
+Micro M Cookie Manager class.
+
+**Inheritance**
+object -> MicroMCookieManager
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/MicroMCookiesManagerSetup/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/MicroMCookiesManagerSetup/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.MicroMCookiesManagerSetup
+## Overview
+Micro M Cookies Manager Setup class.
+
+**Inheritance**
+object -> MicroMCookiesManagerSetup
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/MicroMEncryption/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/MicroMEncryption/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.MicroMEncryption
+## Overview
+Micro M Encryption class.
+
+**Inheritance**
+object -> MicroMEncryption
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/QueueItem/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/QueueItem/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.QueueItem
+## Overview
+Queue Item class.
+
+**Inheritance**
+object -> QueueItem
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/QueueStatusInfo/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/QueueStatusInfo/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.QueueStatusInfo
+## Overview
+Queue Status Info class.
+
+**Inheritance**
+object -> QueueStatusInfo
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/QueueTaskStatus/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/QueueTaskStatus/index.md
@@ -1,0 +1,9 @@
+# Enum: MicroM.Web.Services.QueueTaskStatus
+## Overview
+Queue Task Status enum.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/SSOAuthenticatorResult/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/SSOAuthenticatorResult/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.SSOAuthenticatorResult
+## Overview
+S S O Authenticator Result class.
+
+**Inheritance**
+object -> SSOAuthenticatorResult
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/SSOClientConfiguration/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/SSOClientConfiguration/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.SSOClientConfiguration
+## Overview
+S S O Client Configuration class.
+
+**Inheritance**
+object -> SSOClientConfiguration
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/SSOTokenResult/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/SSOTokenResult/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.SSOTokenResult
+## Overview
+S S O Token Result class.
+
+**Inheritance**
+object -> SSOTokenResult
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/ServeFileResult/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/ServeFileResult/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.ServeFileResult
+## Overview
+Serve File Result class.
+
+**Inheritance**
+object -> ServeFileResult
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/TaskStatusInfo/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/TaskStatusInfo/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.TaskStatusInfo
+## Overview
+Task Status Info class.
+
+**Inheritance**
+object -> TaskStatusInfo
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/UploadFileResult/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/UploadFileResult/index.md
@@ -1,0 +1,15 @@
+# Record: MicroM.Web.Services.UploadFileResult
+## Overview
+Upload File Result record.
+
+**Inheritance**
+object -> UploadFileResult
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/WebAPIBaseExtensions/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/WebAPIBaseExtensions/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.WebAPIBaseExtensions
+## Overview
+Web A P I Base Extensions class.
+
+**Inheritance**
+object -> WebAPIBaseExtensions
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/WebAPIServices/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/WebAPIServices/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.Web.Services.WebAPIServices
+## Overview
+Web A P I Services class.
+
+**Inheritance**
+object -> WebAPIServices
+
+**Implements**
+None
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web.Services/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Services/index.md
@@ -1,0 +1,60 @@
+# Namespace: MicroM.Web.Services
+## Overview
+Web-related service implementations.
+
+## Classes
+| Class | Description |
+|:------------|:-------------|
+| [WebAPIBaseExtensions](WebAPIBaseExtensions/index.md) | Web A P I Base Extensions class. |
+| [WebAPIServices](WebAPIServices/index.md) | Web A P I Services class. |
+| [FileDetails](FileDetails/index.md) | File Details class. |
+| [UploadFileResult](UploadFileResult/index.md) | Upload File Result class. |
+| [FileUploadService](FileUploadService/index.md) | File Upload Service class. |
+| [ServeFileResult](ServeFileResult/index.md) | Serve File Result class. |
+| [MicroMEncryption](MicroMEncryption/index.md) | Micro M Encryption class. |
+| [AuthenticationService](AuthenticationService/index.md) | Authentication Service class. |
+| [ImageThumbnailService](ImageThumbnailService/index.md) | Image Thumbnail Service class. |
+| [EmailServiceDestination](EmailServiceDestination/index.md) | Email Service Destination class. |
+| [EmailServiceItem](EmailServiceItem/index.md) | Email Service Item class. |
+| [EmailServiceTags](EmailServiceTags/index.md) | Email Service Tags class. |
+| [EmailServiceConfigurationData](EmailServiceConfigurationData/index.md) | Email Service Configuration Data class. |
+| [EmailService](EmailService/index.md) | Email Service class. |
+| [EmailHostedService](EmailHostedService/index.md) | Email Hosted Service class. |
+| [MemoryQueueHostedService](MemoryQueueHostedService/index.md) | Memory Queue Hosted Service class. |
+| [TaskStatusInfo](TaskStatusInfo/index.md) | Task Status Info class. |
+| [QueueStatusInfo](QueueStatusInfo/index.md) | Queue Status Info class. |
+| [QueueItem](QueueItem/index.md) | Queue Item class. |
+| [BackgroundTaskQueue](BackgroundTaskQueue/index.md) | Background Task Queue class. |
+| [MicroMAppConfigurationProvider](MicroMAppConfigurationProvider/index.md) | Micro M App Configuration Provider class. |
+| [SSOClientConfiguration](SSOClientConfiguration/index.md) | S S O Client Configuration class. |
+| [SSOTokenResult](SSOTokenResult/index.md) | S S O Token Result class. |
+| [SSOAuthenticatorResult](SSOAuthenticatorResult/index.md) | S S O Authenticator Result class. |
+| [EntitiesService](EntitiesService/index.md) | Entities Service class. |
+| [MicroMCookieManager](MicroMCookieManager/index.md) | Micro M Cookie Manager class. |
+| [MicroMCookiesManagerSetup](MicroMCookiesManagerSetup/index.md) | Micro M Cookies Manager Setup class. |
+
+## Interfaces
+| Interface | Description |
+|:------------|:-------------|
+| [IWebAPIServices](IWebAPIServices/index.md) | Interface for web a p i services. |
+| [IFileUploadService](IFileUploadService/index.md) | Interface for file upload service. |
+| [IMicroMEncryption](IMicroMEncryption/index.md) | Interface for micro m encryption. |
+| [IAuthenticationService](IAuthenticationService/index.md) | Interface for authentication service. |
+| [IThumbnailService](IThumbnailService/index.md) | Interface for thumbnail service. |
+| [IEmailService](IEmailService/index.md) | Interface for email service. |
+| [IMemoryQueueHostedService](IMemoryQueueHostedService/index.md) | Interface for memory queue hosted service. |
+| [IBackgroundTaskQueue](IBackgroundTaskQueue/index.md) | Interface for background task queue. |
+| [IMicroMAppConfiguration](IMicroMAppConfiguration/index.md) | Interface for micro m app configuration. |
+| [IIdentityProviderService](IIdentityProviderService/index.md) | Interface for identity provider service. |
+| [IEntitiesService](IEntitiesService/index.md) | Interface for entities service. |
+
+## Enums
+| Enum | Description |
+|:------------|:-------------|
+| [QueueTaskStatus](QueueTaskStatus/index.md) | Queue Task Status enum. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Web/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web/index.md
@@ -1,0 +1,9 @@
+# Namespace: MicroM.Web
+## Overview
+Root namespace for web functionality.
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/index.md
+++ b/MicroM/Documentation/Backend/index.md
@@ -1,4 +1,4 @@
-| [MicroM.Excel](MicroM.Excel/index.md) | Excel input and output helpers. |# MicroM Backend Documentation
+# MicroM Backend Documentation
 
 This section provides documentation for the MicroM backend namespaces.
 
@@ -16,18 +16,19 @@ This section provides documentation for the MicroM backend namespaces.
 | [MicroM.DataDictionary.StatusDefs](MicroM.DataDictionary.StatusDefs/index.md) | Status definitions for emails, file uploads, imports, and processes. |
 | [MicroM.Database](MicroM.Database/index.md) | Database utilities and schema management. |
 | [MicroM.Excel](MicroM.Excel/index.md) | Excel input and output helpers. |
-| MicroM.Extensions | Documentation not started. |
+| [MicroM.Extensions](MicroM.Extensions/index.md) | Extension helpers. |
 | [MicroM.Generators](MicroM.Generators/index.md) | Utilities for building code generators. |
 | [MicroM.Generators.Extensions](MicroM.Generators.Extensions/index.md) | Extension helpers for generators. |
 | [MicroM.Generators.ReactGenerator](MicroM.Generators.ReactGenerator/index.md) | Generates React TypeScript code for entities. |
 | [MicroM.Generators.SQLGenerator](MicroM.Generators.SQLGenerator/index.md) | Generates SQL DDL and related scripts. |
 | MicroM.ImportData | Documentation not started. |
 | MicroM.Validators | Documentation not started. |
-| MicroM.Web | Documentation not started. |
-| MicroM.Web.Authentication | Documentation not started. |
-| MicroM.Web.Authentication.SSO | Documentation not started. |
-| MicroM.Web.Controllers | Documentation not started. |
-| MicroM.Web.Debug | Documentation not started. |
-| MicroM.Web.Middleware | Documentation not started. |
-| MicroM.Web.Services | Documentation not started. |
-| MicroM.Web.Services.Security | Documentation not started. |
+| [MicroM.Web](MicroM.Web/index.md) | Root web namespace. |
+| [MicroM.Web.Authentication](MicroM.Web.Authentication/index.md) | Authentication utilities for web apps. |
+| [MicroM.Web.Authentication.SSO](MicroM.Web.Authentication.SSO/index.md) | Single sign-on authentication helpers. |
+| [MicroM.Web.Controllers](MicroM.Web.Controllers/index.md) | ASP.NET Core controllers. |
+| [MicroM.Web.Debug](MicroM.Web.Debug/index.md) | Debugging utilities. |
+| [MicroM.Web.Middleware](MicroM.Web.Middleware/index.md) | Middleware components. |
+| [MicroM.Web.Services](MicroM.Web.Services/index.md) | Web service implementations. |
+| [MicroM.Web.Services.Security](MicroM.Web.Services.Security/index.md) | Security-related web services. |
+


### PR DESCRIPTION
## Summary
- document MicroM.Web namespaces for controllers, services, middleware, and security components
- link web namespaces from backend docs index
- update documentation progress for web areas

## Testing
- `dotnet test` *(fails: MSB3073 del command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8af98710483248b3bc5b9efa735ae