### PR TITLE
docs: detail CRC32 methods

### DIFF
--- a/MicroM/Documentation/Backend/MicroM.Core/CRC32/CRC32FromByteArray/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Core/CRC32/CRC32FromByteArray/index.md
@@ -1,0 +1,31 @@
+# MicroM.Core.CRC32.CRC32FromByteArray
+Calculates a CRC-32 checksum for a byte array.
+
+### Syntax
+```csharp
+public static UInt32 CRC32FromByteArray(byte[] bytes)
+```
+
+## Parameters
+| Parameter | Type | Description |
+|:------------|:-------------|:-------------|
+| bytes | [byte[]](https://learn.microsoft.com/dotnet/api/system.byte) | The bytes to compute the checksum for. |
+
+## Returns
+[UInt32](https://learn.microsoft.com/dotnet/api/system.uint32) - The computed CRC-32 checksum.
+
+## Exceptions
+None.
+
+## Example Usage
+```csharp
+byte[] data = Encoding.UTF8.GetBytes("data");
+UInt32 checksum = MicroM.Core.CRC32.CRC32FromByteArray(data);
+```
+
+## Remarks
+Iterates over each byte and updates the checksum using a precomputed table.
+
+## See Also
+- [CRC32](../index.md)
+- [CRCFromString](../CRCFromString/index.md)

--- a/MicroM/Documentation/Backend/MicroM.Core/CRC32/CRCFromString/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Core/CRC32/CRCFromString/index.md
@@ -1,0 +1,30 @@
+# MicroM.Core.CRC32.CRCFromString
+Calculates a CRC-32 checksum for a UTF-8 encoded string.
+
+### Syntax
+```csharp
+public static UInt32 CRCFromString(string string_to_hash)
+```
+
+## Parameters
+| Parameter | Type | Description |
+|:------------|:-------------|:-------------|
+| string_to_hash | [string](https://learn.microsoft.com/dotnet/api/system.string) | The string to compute the checksum for. |
+
+## Returns
+[UInt32](https://learn.microsoft.com/dotnet/api/system.uint32) - The computed CRC-32 checksum.
+
+## Exceptions
+None.
+
+## Example Usage
+```csharp
+UInt32 checksum = MicroM.Core.CRC32.CRCFromString("data");
+```
+
+## Remarks
+Converts the input string to UTF-8 bytes and delegates to [CRC32FromByteArray](../CRC32FromByteArray/index.md).
+
+## See Also
+- [CRC32](../index.md)
+- [CRC32FromByteArray](../CRC32FromByteArray/index.md)

--- a/MicroM/Documentation/Backend/MicroM.Core/CRC32/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Core/CRC32/index.md
@@ -12,11 +12,17 @@ None
 ```csharp
 var checksum = MicroM.Core.CRC32.CRCFromString("data");
 ```
+## Constructors
+None.
+
+## Properties
+None.
+
 ## Methods
 | Method | Description |
 |:------------|:-------------|
-| CRC32FromByteArray(byte[] bytes) | Calculates a CRC-32 checksum from the provided byte array. |
-| CRCFromString(string string_to_hash) | Calculates a CRC-32 checksum from the provided string. |
+| [CRC32FromByteArray](CRC32FromByteArray/index.md) | Calculates a CRC-32 checksum from the provided byte array. |
+| [CRCFromString](CRCFromString/index.md) | Calculates a CRC-32 checksum from the provided string. |
 
 ## Remarks
 None.


### PR DESCRIPTION
## Summary
- expand CRC32 class documentation with template sections for constructors, properties, and methods
- add dedicated docs for CRC32FromByteArray and CRCFromString

## Testing
- `dotnet test MicroM.sln` *(fails: del not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8db83d034832498d76fd0466a1c36