### PR TITLE
docs: document MicroM.Excel namespace

### DIFF
--- a/MicroM/Documentation-Progress/Backend/docs-state-backend.md
+++ b/MicroM/Documentation-Progress/Backend/docs-state-backend.md
@@ -47,8 +47,8 @@ This file tracks the current documentation state of the backend (`/MicroM/core`)
 - Notes: Namespace and classes documented; XML comments pending.
 
 ### MicroM.Excel
-- State: Incomplete ⚠️
-- Notes: Namespace and classes documented; XML comments pending.
+- State: Complete ✅
+- Notes: Namespace and classes documented with XML comments.
 
 ### MicroM.Extensions
 - State: Incomplete ⚠️

--- a/MicroM/Documentation-Progress/Backend/iteration-summary.md
+++ b/MicroM/Documentation-Progress/Backend/iteration-summary.md
@@ -408,3 +408,27 @@
 
 ### Next iteration Tasks
 - Continue documenting remaining `MicroM.Data` types.
+
+---
+
+## Iteration 15
+### Plan
+- Add XML comments for `MicroM.Excel` classes:
+  - `MicroM/core/Excel/DataResultExtensions.cs`
+  - `MicroM/core/Excel/Excel.cs`
+- Update `docs-state-backend.md` for `MicroM.Excel`.
+
+### Execution Results
+- Added XML comments to `DataResultExtensions.cs` → ✅ Success
+- Added XML comments to `Excel.cs` → ✅ Success
+- Updated `docs-state-backend.md` marking `MicroM.Excel` as Complete → ✅ Success
+
+### Verification Results
+- Verified XML comments exist for public members in `MicroM.Excel` → ✅ Success
+- `docs-state-backend.md` lists `MicroM.Excel` as Complete → ✅ Success
+
+### Issues Encountered
+- None
+
+### Next iteration Tasks
+- Continue documenting remaining `MicroM.Data` types.

--- a/MicroM/core/Excel/DataResultExtensions.cs
+++ b/MicroM/core/Excel/DataResultExtensions.cs
@@ -5,8 +5,17 @@ using MicroM.Data;
 
 namespace MicroM.Excel;
 
+/// <summary>
+/// Provides extension methods for exporting <see cref="DataResult"/> instances to Excel.
+/// </summary>
 public static class DataResultExcelExtensions
 {
+    /// <summary>
+    /// Writes the <see cref="DataResult"/> contents to the specified stream in Excel format.
+    /// </summary>
+    /// <param name="data">The source data to export.</param>
+    /// <param name="outputStream">The target stream where the Excel document will be written.</param>
+    /// <param name="sheetName">The name of the worksheet to create.</param>
     public static async Task SaveAsExcelToStreamAsync(this DataResult data, Stream outputStream, string sheetName)
     {
         using var document = SpreadsheetDocument.Create(outputStream, SpreadsheetDocumentType.Workbook, true);

--- a/MicroM/core/Excel/Excel.cs
+++ b/MicroM/core/Excel/Excel.cs
@@ -3,8 +3,18 @@ using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace MicroM.Excel;
 
+/// <summary>
+/// Provides methods for reading data from Excel spreadsheets.
+/// </summary>
 public static class ExcelReader
 {
+    /// <summary>
+    /// Asynchronously reads rows from an Excel stream, starting after the header row.
+    /// </summary>
+    /// <param name="stream">The Excel file stream to read from.</param>
+    /// <param name="sheetName">The worksheet name to read, or <c>null</c> for the first sheet.</param>
+    /// <param name="initialRow">The 1-based header row index.</param>
+    /// <returns>An asynchronous sequence of row values.</returns>
     public static async IAsyncEnumerable<object?[]> ReadExcelAsync(Stream stream, string? sheetName, int initialRow = 1)
     {
         using var document = SpreadsheetDocument.Open(stream, false);


### PR DESCRIPTION
## Summary
- add XML documentation for DataResultExcelExtensions and ExcelReader
- mark MicroM.Excel namespace as complete in documentation state
- record iteration 15 summary

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: del: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e606d7188324b089e6448bdbe757