### PR TITLE
Add XML docs for extension methods

### DIFF
--- a/MicroM/Documentation-Progress/Backend/docs-state-backend.md
+++ b/MicroM/Documentation-Progress/Backend/docs-state-backend.md
@@ -51,8 +51,8 @@ This file tracks the current documentation state of the backend (`/MicroM/core`)
 - Notes: Namespace and classes documented with XML comments.
 
 ### MicroM.Extensions
-- State: Incomplete ⚠️
-- Notes: Namespace and extension classes documented; XML comments missing.
+- State: Complete ✅
+- Notes: Namespace and extension classes documented with XML comments.
 
 ### MicroM.Generators
 - State: Complete ✅

--- a/MicroM/Documentation/Backend/MicroM.Extensions/DataDictionaryExtensions/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Extensions/DataDictionaryExtensions/index.md
@@ -15,6 +15,12 @@ await menuDefinition.AddMenu(entityClient, CancellationToken.None);
 ## Methods
 | Method | Description |
 |:------------|:-------------|
+| AddStatusRelations(EntityBase entity, IEntityClient ec, CancellationToken ct) | Adds related status records for an entity. |
+| AddCategoryRelations(EntityBase entity, IEntityClient ec, CancellationToken ct) | Adds related category records for an entity. |
+| AddCategoryValue(Categories cat, IEntityClient ec, string categoryvalue_id, string description, CancellationToken ct) | Adds a new value to an existing category. |
+| AddStatusValue(Status stat, IEntityClient ec, string statusvalue_id, string description, bool init_value, CancellationToken ct) | Adds a new value to an existing status definition. |
+| AddStatus(StatusDefinition stc, IEntityClient ec, CancellationToken ct) | Creates a status record and its initial value. |
+| AddCategory(CategoryDefinition cac, IEntityClient ec, CancellationToken ct) | Creates a category record and its values. |
 | AddToDataDictionary<T>(T ent, CancellationToken ct) where T : EntityBase, new() | Adds an entity definition to the data dictionary. |
 | AddInstanceToDataDictionary(EntityBase ent, CancellationToken ct) | Persists an entity instance in the data dictionary. |
 | AddMenu(MenuDefinition menu_definition, IEntityClient ec, CancellationToken ct) | Adds a menu definition using the entity client. |

--- a/MicroM/Documentation/Backend/MicroM.Extensions/DatabaseSchemaExtensions/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Extensions/DatabaseSchemaExtensions/index.md
@@ -16,6 +16,8 @@ await typeof(MyAssemblyMarker).Assembly.CreateAssemblyCustomProcs(entityClient, 
 | Method | Description |
 |:------------|:-------------|
 | CreateAssemblyCustomProcs(Assembly assembly, IEntityClient ec, CancellationToken ct, string? mneo = null, string? starts_with = null) | Builds custom procedures defined as embedded SQL resources. |
+| CreateAllCategories(Assembly asm, IEntityClient ec, CancellationToken ct) | Creates all category definitions found in the assembly. |
+| CreateAllStatus(Assembly asm, IEntityClient ec, CancellationToken ct) | Creates all status definitions found in the assembly. |
 
 ## Remarks
 None.

--- a/MicroM/core/Extensions/BooleanExtensions.cs
+++ b/MicroM/core/Extensions/BooleanExtensions.cs
@@ -2,11 +2,25 @@
 
 public static class BooleanExtensions
 {
+    /// <summary>
+    /// Returns <paramref name="true_value"/> when the boolean is true and <paramref name="false_value"/> otherwise.
+    /// </summary>
+    /// <param name="value">Boolean value to evaluate.</param>
+    /// <param name="true_value">String returned when <paramref name="value"/> is true.</param>
+    /// <param name="false_value">String returned when <paramref name="value"/> is false.</param>
+    /// <returns>The appropriate string based on the boolean value.</returns>
     public static string True(this bool value, string true_value, string false_value = "")
     {
         return value ? true_value : false_value;
     }
 
+    /// <summary>
+    /// Returns <paramref name="false_value"/> when the boolean is false and <paramref name="true_value"/> otherwise.
+    /// </summary>
+    /// <param name="value">Boolean value to evaluate.</param>
+    /// <param name="false_value">String returned when <paramref name="value"/> is false.</param>
+    /// <param name="true_value">String returned when <paramref name="value"/> is true.</param>
+    /// <returns>The appropriate string based on the boolean value.</returns>
     public static string False(this bool value, string false_value, string true_value = "")
     {
         return value ? true_value : false_value;

--- a/MicroM/core/Extensions/ColumnExtensions.cs
+++ b/MicroM/core/Extensions/ColumnExtensions.cs
@@ -12,6 +12,14 @@ namespace MicroM.Extensions
 {
     public static class ColumnExtensions
     {
+        /// <summary>
+        /// Retrieves columns that match the specified <paramref name="flags"/> while excluding others.
+        /// </summary>
+        /// <param name="cols">Source column collection.</param>
+        /// <param name="flags">Flags to include.</param>
+        /// <param name="exclude_flags">Flags to exclude.</param>
+        /// <param name="exclude_names">Column names to skip.</param>
+        /// <returns>Dictionary with the matching columns.</returns>
         public static CustomOrderedDictionary<ColumnBase> GetWithFlags(this IReadonlyOrderedDictionary<ColumnBase> cols, ColumnFlags flags, ColumnFlags exclude_flags = ColumnFlags.Fake, params string[] exclude_names)
         {
             var ret = new CustomOrderedDictionary<ColumnBase>();
@@ -24,6 +32,13 @@ namespace MicroM.Extensions
             return ret;
         }
 
+        /// <summary>
+        /// Copies column values from <paramref name="values"/> into <paramref name="cols"/> for the specified names.
+        /// </summary>
+        /// <typeparam name="T">Column collection type.</typeparam>
+        /// <param name="cols">Target columns.</param>
+        /// <param name="values">Source values.</param>
+        /// <param name="names_to_copy">Column names to copy.</param>
         public static void SetColumnValuesByName<T>(this T cols, IReadonlyOrderedDictionary<ColumnBase> values, params string[] names_to_copy) where T : Dictionary<string, ColumnBase>, IReadonlyOrderedDictionary<ColumnBase>
         {
             foreach (ColumnBase value in values.Values)
@@ -33,6 +48,11 @@ namespace MicroM.Extensions
             }
         }
 
+        /// <summary>
+        /// Copies column values from the <paramref name="source"/> dictionary to <paramref name="cols"/> when names match.
+        /// </summary>
+        /// <param name="cols">Destination columns.</param>
+        /// <param name="source">Source columns.</param>
         public static void CopyColumnValuesByName(this IReadonlyOrderedDictionary<ColumnBase> cols, IReadonlyOrderedDictionary<ColumnBase> source)
         {
             foreach (ColumnBase value in source.Values)
@@ -42,16 +62,33 @@ namespace MicroM.Extensions
         }
 
 
+        /// <summary>
+        /// Returns columns that match the specified <paramref name="flags"/>.
+        /// </summary>
+        /// <param name="cols">Source columns.</param>
+        /// <param name="flags">Flags to include.</param>
+        /// <returns>Enumeration of matching columns.</returns>
         public static IEnumerable<ColumnBase> GetParmsWithFlags(this IReadonlyOrderedDictionary<ColumnBase> cols, ColumnFlags flags)
         {
             return cols.GetWithFlags(flags, ColumnFlags.None).Values;
         }
 
+        /// <summary>
+        /// Adds an existing column instance to the collection.
+        /// </summary>
+        /// <param name="collection">Target collection.</param>
+        /// <param name="col">Column to add.</param>
         public static void AddExisting(this CustomOrderedDictionary<ColumnBase> collection, ColumnBase col)
         {
             collection.Add(col.Name, col);
         }
 
+        /// <summary>
+        /// Determines whether all keys from <paramref name="cols"/> exist in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">Source columns.</param>
+        /// <param name="cols">Columns containing keys to check.</param>
+        /// <returns><c>true</c> if all keys are present.</returns>
         public static bool ContainsAllKeys(this IReadonlyOrderedDictionary<ColumnBase> source, IReadonlyOrderedDictionary<ColumnBase> cols)
         {
             foreach (string key in cols.Keys)
@@ -61,6 +98,12 @@ namespace MicroM.Extensions
             return true;
         }
 
+        /// <summary>
+        /// Determines whether all provided <paramref name="keys"/> exist in <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">Source columns.</param>
+        /// <param name="keys">Keys to check.</param>
+        /// <returns><c>true</c> if all keys are present.</returns>
         public static bool ContainsAllKeys(this IReadonlyOrderedDictionary<ColumnBase> source, params string[] keys)
         {
             foreach (string key in keys)
@@ -70,6 +113,11 @@ namespace MicroM.Extensions
             return true;
         }
 
+        /// <summary>
+        /// Encrypts string column values using the provided <paramref name="encryptor"/>.
+        /// </summary>
+        /// <param name="cols">Columns to encrypt.</param>
+        /// <param name="encryptor">Encryption service.</param>
         public static void EncryptColumnData(this IEnumerable<ColumnBase> cols, IMicroMEncryption encryptor)
         {
             foreach (ColumnBase col in cols)
@@ -81,6 +129,11 @@ namespace MicroM.Extensions
             }
         }
 
+        /// <summary>
+        /// Decrypts string column values using the provided <paramref name="encryptor"/>.
+        /// </summary>
+        /// <param name="cols">Columns to decrypt.</param>
+        /// <param name="encryptor">Encryption service.</param>
         public static void DecryptColumnData(this IEnumerable<ColumnBase> cols, IMicroMEncryption encryptor)
         {
             foreach (ColumnBase col in cols)
@@ -92,6 +145,12 @@ namespace MicroM.Extensions
             }
         }
 
+        /// <summary>
+        /// Maps column values to a new instance of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">Destination record type.</typeparam>
+        /// <param name="cols">Source columns.</param>
+        /// <returns>Instance of <typeparamref name="T"/> populated with column values.</returns>
         public static T MapColumnData<T>(this IReadonlyOrderedDictionary<ColumnBase> cols) where T : class, new()
         {
             var members = typeof(T).GetMembers(BindingFlags.Public | BindingFlags.Instance).Where(p => p.MemberType.IsIn(MemberTypes.Property, MemberTypes.Field) && p.GetCustomAttribute<CompilerGeneratedAttribute>() == null);
@@ -120,6 +179,20 @@ namespace MicroM.Extensions
         }
 
 
+        /// <summary>
+        /// Adds a new column definition to the collection.
+        /// </summary>
+        /// <typeparam name="T">Column value type.</typeparam>
+        /// <param name="collection">Target collection.</param>
+        /// <param name="name">Column name.</param>
+        /// <param name="sql_type">SQL type of the column.</param>
+        /// <param name="size">Column size.</param>
+        /// <param name="precision">Numeric precision.</param>
+        /// <param name="scale">Numeric scale.</param>
+        /// <param name="value">Initial value.</param>
+        /// <param name="output">Whether the column is an output parameter.</param>
+        /// <param name="column_flags">Flags describing column behavior.</param>
+        /// <returns>The created column.</returns>
         public static Column<T> AddCol<T>(this CustomOrderedDictionary<ColumnBase> collection, string name, SqlDbType? sql_type, int size = 0, byte precision = 0, byte scale = 0,
             T value = default!, bool output = false, ColumnFlags column_flags = ColumnFlags.Insert | ColumnFlags.Update)
         {
@@ -128,6 +201,19 @@ namespace MicroM.Extensions
             return col;
         }
 
+        /// <summary>
+        /// Adds a primary key column definition.
+        /// </summary>
+        /// <typeparam name="T">Column value type.</typeparam>
+        /// <param name="collection">Target collection.</param>
+        /// <param name="name">Column name.</param>
+        /// <param name="sql_type">SQL type of the column.</param>
+        /// <param name="size">Column size.</param>
+        /// <param name="precision">Numeric precision.</param>
+        /// <param name="scale">Numeric scale.</param>
+        /// <param name="value">Initial value.</param>
+        /// <param name="autonum">Whether the column is auto-numbered.</param>
+        /// <returns>The created primary key column.</returns>
         public static Column<T> AddPK<T>(this CustomOrderedDictionary<ColumnBase> collection, string name, SqlDbType? sql_type = SqlDbType.Char, int size = 20, byte precision = 0, byte scale = 0,
             T value = default!, bool autonum = false)
         {
@@ -139,12 +225,29 @@ namespace MicroM.Extensions
             return col;
         }
 
+        /// <summary>
+        /// Adds a foreign key column definition.
+        /// </summary>
+        /// <typeparam name="T">Column value type.</typeparam>
+        /// <param name="collection">Target collection.</param>
+        /// <param name="name">Column name.</param>
+        /// <param name="sql_type">SQL type of the column.</param>
+        /// <param name="size">Column size.</param>
+        /// <param name="precision">Numeric precision.</param>
+        /// <param name="scale">Numeric scale.</param>
+        /// <param name="value">Initial value.</param>
+        /// <returns>The created foreign key column.</returns>
         public static Column<T> AddFK<T>(this CustomOrderedDictionary<ColumnBase> collection, string name, SqlDbType? sql_type = SqlDbType.Char, int size = 20, byte precision = 0, byte scale = 0, T value = default!)
         {
             return collection.AddCol(name, value: value, sql_type: sql_type, size: size, precision: precision,
                 scale: scale, column_flags: ColumnFlags.Insert | ColumnFlags.Update | ColumnFlags.Delete | ColumnFlags.Get | ColumnFlags.FK);
         }
 
+        /// <summary>
+        /// Creates a <see cref="SqlParameter"/> from the specified column.
+        /// </summary>
+        /// <param name="sql_col">Column used to build the parameter.</param>
+        /// <returns>The created parameter.</returns>
         public static SqlParameter CreateSQLParameter(this ColumnBase sql_col)
         {
             var parm = new SqlParameter
@@ -168,6 +271,11 @@ namespace MicroM.Extensions
         }
 
 
+        /// <summary>
+        /// Converts a collection of columns into an array of <see cref="SqlParameter"/>.
+        /// </summary>
+        /// <param name="sql_cols">Columns to convert.</param>
+        /// <returns>Array of SQL parameters.</returns>
         public static SqlParameter[] AsSqlParameters(this IEnumerable<ColumnBase> sql_cols)
         {
             var ret = new List<SqlParameter>();
@@ -178,6 +286,11 @@ namespace MicroM.Extensions
             return [.. ret];
         }
 
+        /// <summary>
+        /// Removes table prefix from a column name if present.
+        /// </summary>
+        /// <param name="column_name">Column name with optional prefix.</param>
+        /// <returns>Column name without prefix.</returns>
         public static string StripColumnPrefix(this string column_name)
         {
             int prefix_idx = column_name.IndexOf('_');
@@ -190,6 +303,16 @@ namespace MicroM.Extensions
             return column_name;
         }
 
+        /// <summary>
+        /// Converts a column to a <see cref="ViewParm"/> definition.
+        /// </summary>
+        /// <param name="column">Source column.</param>
+        /// <param name="column_mapping">Optional column mapping.</param>
+        /// <param name="compound_group">Compound group name.</param>
+        /// <param name="compound_position">Position inside compound group.</param>
+        /// <param name="compound_key">Indicates if part of compound key.</param>
+        /// <param name="browsing_key">Indicates if used for browsing.</param>
+        /// <returns>New <see cref="ViewParm"/> instance.</returns>
         public static ViewParm AsViewItemParm(this ColumnBase column, int column_mapping = -1, string compound_group = "", int compound_position = -1, bool compound_key = false, bool browsing_key = false)
         {
             Type SQLColType = typeof(Column<>).MakeGenericType(column.SystemType);
@@ -198,6 +321,12 @@ namespace MicroM.Extensions
             return new ViewParm(col, column_mapping, compound_group, compound_position, compound_key, browsing_key);
         }
 
+        /// <summary>
+        /// Converts columns to a dictionary of name and value pairs.
+        /// </summary>
+        /// <param name="cols">Source columns.</param>
+        /// <param name="exclude_colnames">Optional set of column names to exclude.</param>
+        /// <returns>Dictionary of column values.</returns>
         public static Dictionary<string, object?> ToDictionary(this IReadonlyOrderedDictionary<ColumnBase> cols, HashSet<string>? exclude_colnames = null)
         {
             Dictionary<string, object?> ret = new(StringComparer.OrdinalIgnoreCase);
@@ -211,6 +340,12 @@ namespace MicroM.Extensions
             return ret;
         }
 
+        /// <summary>
+        /// Creates a dictionary keyed by column name from the provided columns.
+        /// </summary>
+        /// <param name="cols">Source columns.</param>
+        /// <param name="exclude_colnames">Optional set of column names to exclude.</param>
+        /// <returns>Dictionary of columns.</returns>
         public static Dictionary<string, ColumnBase> ToColumnsDictionary(this IReadonlyOrderedDictionary<ColumnBase> cols, HashSet<string>? exclude_colnames = null)
         {
             Dictionary<string, ColumnBase> ret = new(StringComparer.OrdinalIgnoreCase);
@@ -225,6 +360,13 @@ namespace MicroM.Extensions
         }
 
 
+        /// <summary>
+        /// Attempts to convert a string value into the column's data type.
+        /// </summary>
+        /// <param name="col">Target column.</param>
+        /// <param name="value_to_convert">String value to convert.</param>
+        /// <param name="converted_value">Resulting value if conversion succeeds.</param>
+        /// <returns><c>true</c> if conversion was successful.</returns>
         public static bool TryConvertFromString(this ColumnBase col, string? value_to_convert, out object? converted_value)
         {
             bool ret = false;
@@ -330,6 +472,13 @@ namespace MicroM.Extensions
         }
 
 
+        /// <summary>
+        /// Attempts to convert a <see cref="JsonElement"/> to the specified type.
+        /// </summary>
+        /// <typeparam name="T">Target type.</typeparam>
+        /// <param name="source">JSON element to convert.</param>
+        /// <param name="result">Converted result when successful.</param>
+        /// <returns><c>true</c> if conversion succeeded.</returns>
         public static bool TryConvertFromJsonElement<T>(this JsonElement source, out T result)
         {
             var type = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
@@ -359,6 +508,13 @@ namespace MicroM.Extensions
             return false;
         }
 
+        /// <summary>
+        /// Attempts to convert a <see cref="JsonElement"/> into a value compatible with the specified column.
+        /// </summary>
+        /// <param name="element">JSON element to convert.</param>
+        /// <param name="col">Target column definition.</param>
+        /// <param name="converted_value">Resulting value when successful.</param>
+        /// <returns><c>true</c> if conversion succeeded.</returns>
         public static bool TryConvertFromJsonElement(this JsonElement element, ColumnBase col, out object? converted_value)
         {
             bool ret = false;

--- a/MicroM/core/Extensions/CoreExtensions.cs
+++ b/MicroM/core/Extensions/CoreExtensions.cs
@@ -6,6 +6,14 @@ namespace MicroM.Extensions
 {
     public static class CoreExtensions
     {
+        /// <summary>
+        /// Adds a new procedure definition to the collection and registers its parameters.
+        /// </summary>
+        /// <param name="collection">Procedure collection.</param>
+        /// <param name="name">Procedure name.</param>
+        /// <param name="readonly_locks">Indicates if the procedure uses read-only locks.</param>
+        /// <param name="parms">Parameters to add.</param>
+        /// <returns>The created procedure definition.</returns>
         public static ProcedureDefinition AddProc(this Dictionary<string, ProcedureDefinition> collection, string name, bool readonly_locks = false, params ColumnBase[] parms)
         {
             var proc = new ProcedureDefinition(name, readonly_locks);
@@ -17,6 +25,17 @@ namespace MicroM.Extensions
             return proc;
         }
 
+        /// <summary>
+        /// Registers a foreign key definition in the collection.
+        /// </summary>
+        /// <typeparam name="TParent">Parent entity type.</typeparam>
+        /// <typeparam name="TChild">Child entity type.</typeparam>
+        /// <param name="collection">Foreign key collection.</param>
+        /// <param name="name">Foreign key name.</param>
+        /// <param name="fake">Indicates a fake foreign key.</param>
+        /// <param name="do_not_create_index">Prevents index creation when true.</param>
+        /// <param name="key_mappings">Optional column mappings.</param>
+        /// <returns>The created foreign key definition.</returns>
         public static EntityForeignKey<TParent, TChild> AddFK<TParent, TChild>(this Dictionary<string, EntityForeignKeyBase> collection, string name, bool fake = false, bool do_not_create_index = false, List<BaseColumnMapping>? key_mappings = null) where TParent : EntityBase where TChild : EntityBase
         {
             var fk = new EntityForeignKey<TParent, TChild>(name, fake, do_not_create_index, key_mappings);
@@ -25,6 +44,14 @@ namespace MicroM.Extensions
         }
 
 
+        /// <summary>
+        /// Adds a new view definition to the collection and optionally adds default parameters.
+        /// </summary>
+        /// <param name="collection">View collection.</param>
+        /// <param name="name">View name.</param>
+        /// <param name="add_default_parms">Whether to add default parameters.</param>
+        /// <param name="parms_columns">Optional columns used for parameters.</param>
+        /// <returns>The created view definition.</returns>
         public static ViewDefinition AddView(this Dictionary<string, ViewDefinition> collection, string name, bool add_default_parms = true, IReadonlyOrderedDictionary<ColumnBase>? parms_columns = null)
         {
             ViewDefinition view = new(name, add_default_parms);
@@ -41,6 +68,11 @@ namespace MicroM.Extensions
             return view;
         }
 
+        /// <summary>
+        /// Sets key column values on the entity from the provided dictionary.
+        /// </summary>
+        /// <param name="entity">Entity instance.</param>
+        /// <param name="values">Values keyed by column name.</param>
         public static void SetKeyValues(this EntityBase entity, Dictionary<string, object> values)
         {
             foreach (string key in values.Keys)
@@ -55,6 +87,11 @@ namespace MicroM.Extensions
             }
         }
 
+        /// <summary>
+        /// Assigns column values on an entity using a dictionary of values.
+        /// </summary>
+        /// <param name="entity">Entity instance.</param>
+        /// <param name="values">Values keyed by column name.</param>
         public static void SetColumnValues(this EntityBase entity, Dictionary<string, object> values)
         {
             foreach (string key in values.Keys)
@@ -66,6 +103,12 @@ namespace MicroM.Extensions
             }
         }
 
+        /// <summary>
+        /// Sets a single column value on an entity.
+        /// </summary>
+        /// <param name="entity">Entity instance.</param>
+        /// <param name="col_name">Column name.</param>
+        /// <param name="values">Dictionary containing the value.</param>
         public static void SetColumnValue(this EntityBase entity, string col_name, Dictionary<string, object> values)
         {
             if (entity.Def.Columns.TryGetValue(col_name, out ColumnBase? col))
@@ -74,6 +117,14 @@ namespace MicroM.Extensions
             }
         }
 
+        /// <summary>
+        /// Defines a procedure for the entity definition using the specified columns.
+        /// </summary>
+        /// <typeparam name="T">Entity definition type.</typeparam>
+        /// <param name="def">Entity definition instance.</param>
+        /// <param name="readonly_locks">Indicates if the procedure uses read-only locks.</param>
+        /// <param name="column_names">Names of columns to include as parameters.</param>
+        /// <returns>The created procedure definition.</returns>
         public static ProcedureDefinition DefineProc<T>(this T def, bool readonly_locks = false, params string[] column_names) where T : EntityDefinition
         {
             if (column_names.Length == 0)
@@ -92,11 +143,23 @@ namespace MicroM.Extensions
             return new ProcedureDefinition("", readonly_locks, default, parms);
         }
 
+        /// <summary>
+        /// Returns the SQL table name for the specified entity type.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <returns>The SQL table name.</returns>
         public static string ToTableName<T>()
         {
             return typeof(T).Name.ToSQLName();
         }
 
+        /// <summary>
+        /// Creates a copy of the entity optionally cloning its connection.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="original">Original entity.</param>
+        /// <param name="clone_connection">Whether to clone the entity's connection.</param>
+        /// <returns>A new entity instance with copied values.</returns>
         public static T Clone<T>(this T original, bool clone_connection) where T : EntityBase, new()
         {
             IEntityClient ec = clone_connection ? original.Client.Clone() : original.Client;
@@ -117,6 +180,12 @@ namespace MicroM.Extensions
             entity.Def.Columns.CopyColumnValuesByName(source.Def.Columns);
         }
 
+        /// <summary>
+        /// Checks whether a file extension is among the allowed extensions.
+        /// </summary>
+        /// <param name="fileName">File name to inspect.</param>
+        /// <param name="allowedExtensions">Array of allowed extensions.</param>
+        /// <returns>Tuple indicating if the extension is allowed and the extension value.</returns>
         public static (bool allowed, string extension) IsFileExtensionAllowed(this string fileName, string[] allowedExtensions)
         {
             var fileExtension = Path.GetExtension(fileName);

--- a/MicroM/core/Extensions/DataDictionaryExtensions.cs
+++ b/MicroM/core/Extensions/DataDictionaryExtensions.cs
@@ -170,12 +170,24 @@ public static class DataDictionaryExtensions
         return cat;
     }
 
-
+    /// <summary>
+    /// Adds an entity definition to the data dictionary.
+    /// </summary>
+    /// <typeparam name="T">Entity type.</typeparam>
+    /// <param name="ent">Entity instance to register.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The registered entity.</returns>
     public static async Task<T> AddToDataDictionary<T>(this T ent, CancellationToken ct) where T : EntityBase, new()
     {
         return (T)await AddInstanceToDataDictionary(ent, ct);
     }
 
+    /// <summary>
+    /// Inserts the entity and related metadata into the data dictionary.
+    /// </summary>
+    /// <param name="ent">Entity instance.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The inserted entity.</returns>
     public static async Task<EntityBase> AddInstanceToDataDictionary(this EntityBase ent, CancellationToken ct)
     {
         var ec = ent.Client;
@@ -202,6 +214,12 @@ public static class DataDictionaryExtensions
         return ent;
     }
 
+    /// <summary>
+    /// Adds a menu definition and its items to the data dictionary.
+    /// </summary>
+    /// <param name="menu_definition">Menu definition to insert.</param>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="ct">Cancellation token.</param>
     public static async Task AddMenu(this MenuDefinition menu_definition, IEntityClient ec, CancellationToken ct)
     {
         bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -260,6 +278,12 @@ public static class DataDictionaryExtensions
         }
     }
 
+    /// <summary>
+    /// Adds a user group definition to the data dictionary with its allowed menu items.
+    /// </summary>
+    /// <param name="user_group">User group definition.</param>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="ct">Cancellation token.</param>
     public static async Task AddUserGroup(this UsersGroupDefinition user_group, IEntityClient ec, CancellationToken ct)
     {
         bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);

--- a/MicroM/core/Extensions/DataExtensions.cs
+++ b/MicroM/core/Extensions/DataExtensions.cs
@@ -9,12 +9,24 @@ namespace MicroM.Extensions
 {
     public static class DataExtensions
     {
+        /// <summary>
+        /// Determines whether the result set contains any records.
+        /// </summary>
+        /// <param name="result">Result list to inspect.</param>
+        /// <returns><c>true</c> if data exists.</returns>
         public static bool HasData(this List<DataResult>? result)
         {
             if (result != null && result.Count > 0 && result[0].records.Count > 0) return true;
             return false;
         }
 
+        /// <summary>
+        /// Converts a record into a dictionary of string values keyed by header.
+        /// </summary>
+        /// <param name="result">Data result containing records.</param>
+        /// <param name="record_index">Record index to convert.</param>
+        /// <param name="comparer">Optional key comparer.</param>
+        /// <returns>Dictionary of header names and string values.</returns>
         public static Dictionary<string, string> ToDictionaryOfStringRecord(this DataResult result, int record_index, StringComparer? comparer)
         {
             if (result.records.Count == 0) return [];
@@ -31,6 +43,12 @@ namespace MicroM.Extensions
             return dict;
         }
 
+        /// <summary>
+        /// Returns a list of non-empty values from the specified column.
+        /// </summary>
+        /// <param name="result">Data result containing records.</param>
+        /// <param name="header_index">Column index.</param>
+        /// <returns>List of string values.</returns>
         public static List<string> ToListOfStringColumn(this DataResult result, int header_index)
         {
             if (result.records.Count == 0) return [];
@@ -48,6 +66,12 @@ namespace MicroM.Extensions
             return column_records;
         }
 
+        /// <summary>
+        /// Converts a record into a dictionary of objects keyed by header.
+        /// </summary>
+        /// <param name="result">Data result.</param>
+        /// <param name="record_index">Record index to convert.</param>
+        /// <returns>Dictionary of header names and values.</returns>
         public static Dictionary<string, object> ToDictionary(this DataResult result, int record_index)
         {
             if (result.records.Count == 0) return [];
@@ -64,6 +88,12 @@ namespace MicroM.Extensions
             return dict;
         }
 
+        /// <summary>
+        /// Gets the header index for the specified column name.
+        /// </summary>
+        /// <param name="result">Data result.</param>
+        /// <param name="column_name">Column name to search.</param>
+        /// <returns>Index of the column or null if not found.</returns>
         public static int? GetHeaderIndex(this DataResult result, string column_name)
         {
             if (result == null) return null;
@@ -75,13 +105,13 @@ namespace MicroM.Extensions
         }
 
         /// <summary>
-        /// Returns the column value for <paramref name="column_name"/> for record_index <paramref name="record"/>
+        /// Retrieves a typed value from the specified record and column.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="result"></param>
-        /// <param name="column_name"></param>
-        /// <param name="record"></param>
-        /// <returns></returns>
+        /// <typeparam name="TColumn">Type of the value.</typeparam>
+        /// <param name="result">Data result.</param>
+        /// <param name="column_name">Column name to access.</param>
+        /// <param name="record">Record index.</param>
+        /// <returns>Value of the column or default.</returns>
         public static TColumn? Get<TColumn>(this DataResult result, string column_name, int record)
         {
             if (result == null) return default;
@@ -104,6 +134,11 @@ namespace MicroM.Extensions
             }
         }
 
+        /// <summary>
+        /// Produces a textual representation of a SQL command with parameters.
+        /// </summary>
+        /// <param name="cmd">SQL command.</param>
+        /// <returns>Traceable SQL string.</returns>
         public static string TraceSQL(this SqlCommand cmd)
         {
             if (cmd.CommandType == CommandType.Text) return cmd.CommandText;
@@ -130,6 +165,12 @@ namespace MicroM.Extensions
             return $"exec {cmd.CommandText} {parms}";
         }
 
+        /// <summary>
+        /// Parses a JSON string array into a string array.
+        /// </summary>
+        /// <param name="json_string_array">JSON string to parse.</param>
+        /// <param name="dont_throw_exception">If true, returns null on parse error.</param>
+        /// <returns>Array of strings or null.</returns>
         public static string[]? FromJsonStringArray(this string? json_string_array, bool dont_throw_exception = true)
         {
             if (string.IsNullOrWhiteSpace(json_string_array)) return null;

--- a/MicroM/core/Extensions/DatabaseSchemaExtensions.cs
+++ b/MicroM/core/Extensions/DatabaseSchemaExtensions.cs
@@ -6,6 +6,14 @@ namespace MicroM.Extensions
 {
     public static class DatabaseSchemaExtensions
     {
+        /// <summary>
+        /// Executes custom SQL procedures embedded in the assembly resources.
+        /// </summary>
+        /// <param name="assembly">Assembly containing resources.</param>
+        /// <param name="ec">Entity client used to execute scripts.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <param name="mneo">Optional mneo filter.</param>
+        /// <param name="starts_with">Optional name prefix filter.</param>
         public static async Task CreateAssemblyCustomProcs(this Assembly assembly, IEntityClient ec, CancellationToken ct, string? mneo = null, string? starts_with = null)
         {
             foreach (string script in await assembly.GetAssemblyCustomProcs(mneo, starts_with, ct))
@@ -21,6 +29,12 @@ namespace MicroM.Extensions
             }
         }
 
+        /// <summary>
+        /// Creates all category definitions discovered in the assembly.
+        /// </summary>
+        /// <param name="asm">Assembly to scan.</param>
+        /// <param name="ec">Entity client.</param>
+        /// <param name="ct">Cancellation token.</param>
         public async static Task CreateAllCategories(this Assembly asm, IEntityClient ec, CancellationToken ct)
         {
             bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -41,6 +55,12 @@ namespace MicroM.Extensions
             }
         }
 
+        /// <summary>
+        /// Creates all status definitions discovered in the assembly.
+        /// </summary>
+        /// <param name="asm">Assembly to scan.</param>
+        /// <param name="ec">Entity client.</param>
+        /// <param name="ct">Cancellation token.</param>
         public async static Task CreateAllStatus(this Assembly asm, IEntityClient ec, CancellationToken ct)
         {
             bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);

--- a/MicroM/core/Extensions/EmbeddedResourcesExtensions.cs
+++ b/MicroM/core/Extensions/EmbeddedResourcesExtensions.cs
@@ -4,6 +4,14 @@ namespace MicroM.Extensions;
 
 public static class EmbeddedResourcesExtensions
 {
+    /// <summary>
+    /// Retrieves all embedded SQL procedure scripts for the specified assembly type.
+    /// </summary>
+    /// <typeparam name="T">Type whose assembly is scanned.</typeparam>
+    /// <param name="assembly_class">Instance used to obtain the assembly.</param>
+    /// <param name="mneo">Optional mneo filter.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>List of SQL script contents.</returns>
     public async static Task<List<string>> GetAllCustomProcs<T>(this T assembly_class, string? mneo, CancellationToken ct) where T : class
     {
         var assembly = typeof(T).Assembly;
@@ -24,6 +32,14 @@ public static class EmbeddedResourcesExtensions
         return ret;
     }
 
+    /// <summary>
+    /// Retrieves embedded SQL procedure scripts from the given assembly.
+    /// </summary>
+    /// <param name="assembly">Assembly to inspect.</param>
+    /// <param name="mneo">Optional mneo filter.</param>
+    /// <param name="starts_with">Optional prefix filter for resource names.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>List of SQL script contents.</returns>
     public async static Task<List<string>> GetAssemblyCustomProcs(this Assembly assembly, string? mneo, string? starts_with, CancellationToken ct)
     {
         List<string> ret = [];

--- a/MicroM/core/Extensions/GenericExtensions.cs
+++ b/MicroM/core/Extensions/GenericExtensions.cs
@@ -5,7 +5,14 @@ namespace MicroM.Extensions
 {
     public static class GenericExtensions
     {
-
+        /// <summary>
+        /// Determines if a value exists within the provided array using an optional comparer.
+        /// </summary>
+        /// <typeparam name="T">Value type.</typeparam>
+        /// <param name="value">Value to search for.</param>
+        /// <param name="parms">Array of values.</param>
+        /// <param name="comparer">Comparer to use.</param>
+        /// <returns><c>true</c> if the value is found.</returns>
         public static bool IsIn<T>(this T value, T[] parms, IEqualityComparer<T>? comparer = null)
         {
             comparer ??= EqualityComparer<T>.Default;
@@ -18,6 +25,15 @@ namespace MicroM.Extensions
             return false;
         }
 
+        /// <summary>
+        /// Determines if all values in the array are equal to the specified value.
+        /// </summary>
+        /// <typeparam name="T">Value type.</typeparam>
+        /// <param name="value">Value to compare.</param>
+        /// <param name="parms">Array of values.</param>
+        /// <param name="ignore_null">Whether to ignore null values.</param>
+        /// <param name="comparer">Comparer to use.</param>
+        /// <returns><c>true</c> if all values are equal.</returns>
         public static bool AreAllEqual<T>(this T value, T[] parms, bool ignore_null = false, IEqualityComparer<T>? comparer = null)
         {
             comparer ??= EqualityComparer<T>.Default;
@@ -31,6 +47,13 @@ namespace MicroM.Extensions
             return true;
         }
 
+        /// <summary>
+        /// Determines if a value exists within the provided array using default comparison.
+        /// </summary>
+        /// <typeparam name="T">Value type.</typeparam>
+        /// <param name="value">Value to search for.</param>
+        /// <param name="parms">Array of values.</param>
+        /// <returns><c>true</c> if the value is found.</returns>
         public static bool IsIn<T>(this T value, params T[] parms)
         {
             if (parms == null) return false;
@@ -41,6 +64,13 @@ namespace MicroM.Extensions
             return false;
         }
 
+        /// <summary>
+        /// Checks whether any of the specified flags are set on the value.
+        /// </summary>
+        /// <typeparam name="T">Enum type.</typeparam>
+        /// <param name="value">Value to check.</param>
+        /// <param name="flags">Flags to evaluate.</param>
+        /// <returns><c>true</c> if any flag is set.</returns>
         public static bool HasAnyFlag<T>(this T value, T flags) where T : Enum
         {
             int intValue = Convert.ToInt32(value, CultureInfo.InvariantCulture);
@@ -49,6 +79,13 @@ namespace MicroM.Extensions
             return (intValue & intFlags) > 0 || intValue == intFlags;
         }
 
+        /// <summary>
+        /// Checks whether all specified flags are set on the value.
+        /// </summary>
+        /// <typeparam name="T">Enum type.</typeparam>
+        /// <param name="value">Value to check.</param>
+        /// <param name="flags">Flags to evaluate.</param>
+        /// <returns><c>true</c> if all flags are set.</returns>
         public static bool HasAllFlags<T>(this T value, T flags) where T : Enum
         {
             int intValue = Convert.ToInt32(value, CultureInfo.InvariantCulture);
@@ -57,6 +94,13 @@ namespace MicroM.Extensions
             return (intValue & intFlags) == intFlags;
         }
 
+        /// <summary>
+        /// Attempts to convert a string into the specified value type.
+        /// </summary>
+        /// <typeparam name="T">Value type.</typeparam>
+        /// <param name="source">Source string.</param>
+        /// <param name="result">Converted result when successful.</param>
+        /// <returns><c>true</c> if conversion succeeded.</returns>
         public static bool TryConvertFromString<T>(this string source, out T? result) where T : struct
         {
             var type = typeof(T);
@@ -78,10 +122,23 @@ namespace MicroM.Extensions
             return false;
         }
 
+        /// <summary>
+        /// Determines whether a collection is null or empty.
+        /// </summary>
+        /// <typeparam name="T">Element type.</typeparam>
+        /// <param name="collection">Collection to test.</param>
+        /// <returns><c>true</c> if the collection is null or empty.</returns>
         public static bool IsNullOrEmpty<T>(this T? collection) where T : ICollection<T>
         {
             return collection?.Count > 0;
         }
+
+        /// <summary>
+        /// Determines whether a list is null or empty.
+        /// </summary>
+        /// <typeparam name="T">Element type.</typeparam>
+        /// <param name="collection">List to test.</param>
+        /// <returns><c>true</c> if the list is null or empty.</returns>
         public static bool IsNullOrEmpty<T>(this IList<T>? collection)
         {
             return collection?.Count > 0;

--- a/MicroM/core/Extensions/ProcedureExtensions.cs
+++ b/MicroM/core/Extensions/ProcedureExtensions.cs
@@ -5,6 +5,11 @@ namespace MicroM.Extensions
 {
     public static class ProcedureExtensions
     {
+        /// <summary>
+        /// Sets procedure parameter values from the provided dictionary.
+        /// </summary>
+        /// <param name="proc">Procedure definition.</param>
+        /// <param name="values">Parameter values keyed by name.</param>
         public static void SetParmsValues(this ProcedureDefinition proc, Dictionary<string, object> values)
         {
             foreach (var key in values.Keys)
@@ -15,6 +20,11 @@ namespace MicroM.Extensions
                 }
             }
         }
+        /// <summary>
+        /// Sets procedure parameter values from a column collection.
+        /// </summary>
+        /// <param name="proc">Procedure definition.</param>
+        /// <param name="cols">Source column values.</param>
         public static void SetParmsValues(this ProcedureDefinition proc, IReadonlyOrderedDictionary<ColumnBase> cols)
         {
             foreach (var key in cols.Keys)

--- a/MicroM/core/Extensions/ReflectionExtensions.cs
+++ b/MicroM/core/Extensions/ReflectionExtensions.cs
@@ -9,18 +9,34 @@ namespace MicroM.Extensions;
 public static class ReflectionExtensions
 {
 
+    /// <summary>
+    /// Adds the type <typeparamref name="T"/> to the dictionary keyed by its name.
+    /// </summary>
+    /// <typeparam name="T">Type to register.</typeparam>
+    /// <param name="dict">Dictionary to update.</param>
     public static void TryAddType<T>(this Dictionary<string, Type> dict)
     {
         var entity_type = typeof(T);
         dict.TryAdd(entity_type.Name, entity_type);
     }
 
+    /// <summary>
+    /// Adds the type <typeparamref name="T"/> to the ordered dictionary keyed by its name.
+    /// </summary>
+    /// <typeparam name="T">Type to register.</typeparam>
+    /// <param name="dict">Ordered dictionary to update.</param>
     public static void TryAddType<T>(this CustomOrderedDictionary<Type> dict)
     {
         var entity_type = typeof(T);
         dict.TryAdd(entity_type.Name, entity_type);
     }
 
+    /// <summary>
+    /// Gets the value of a member (field or property) for the specified instance.
+    /// </summary>
+    /// <param name="member">Member to read.</param>
+    /// <param name="instance">Object instance.</param>
+    /// <returns>Member value.</returns>
     public static object? GetMemberValue(this MemberInfo member, object instance)
     {
         if (member.MemberType == MemberTypes.Field)
@@ -36,6 +52,11 @@ public static class ReflectionExtensions
 
     }
 
+    /// <summary>
+    /// Gets the type of a member (field or property).
+    /// </summary>
+    /// <param name="member">Member information.</param>
+    /// <returns>Type of the member.</returns>
     public static Type GetMemberType(this MemberInfo member)
     {
         if (member.MemberType == MemberTypes.Field)
@@ -50,6 +71,11 @@ public static class ReflectionExtensions
 
     }
 
+    /// <summary>
+    /// Retrieves all entity types defined in the assembly.
+    /// </summary>
+    /// <param name="asm">Assembly to scan.</param>
+    /// <returns>Dictionary of entity type names and types.</returns>
     public static Dictionary<string, Type> GetEntitiesTypes(this Assembly asm)
     {
         Dictionary<string, Type> entitiesTypes = new(StringComparer.OrdinalIgnoreCase);
@@ -63,6 +89,11 @@ public static class ReflectionExtensions
         return entitiesTypes;
     }
 
+    /// <summary>
+    /// Retrieves all category definition types defined in the assembly.
+    /// </summary>
+    /// <param name="asm">Assembly to scan.</param>
+    /// <returns>Dictionary of category type names and types.</returns>
     public static Dictionary<string, Type> GetCategoriesTypes(this Assembly asm)
     {
         Dictionary<string, Type> categoriesTypes = new(StringComparer.OrdinalIgnoreCase);
@@ -76,6 +107,11 @@ public static class ReflectionExtensions
         return categoriesTypes;
     }
 
+    /// <summary>
+    /// Retrieves all category definition types from the provided assemblies.
+    /// </summary>
+    /// <param name="assemblies">List of assemblies to scan.</param>
+    /// <returns>Dictionary of category type names and types.</returns>
     public static Dictionary<string, Type> GetAllCategoriesTypes(this List<Assembly> assemblies)
     {
         return assemblies
@@ -84,6 +120,11 @@ public static class ReflectionExtensions
             .ToDictionary(type => type.Name, type => type);
     }
 
+    /// <summary>
+    /// Retrieves all status definition types defined in the assembly.
+    /// </summary>
+    /// <param name="asm">Assembly to scan.</param>
+    /// <returns>Dictionary of status type names and types.</returns>
     public static Dictionary<string, Type> GetStatusTypes(this Assembly asm)
     {
         Dictionary<string, Type> statusTypes = new(StringComparer.OrdinalIgnoreCase);
@@ -97,6 +138,12 @@ public static class ReflectionExtensions
         return statusTypes;
     }
 
+    /// <summary>
+    /// Retrieves all class types implementing the specified interface.
+    /// </summary>
+    /// <typeparam name="T">Interface type.</typeparam>
+    /// <param name="asm">Assembly to scan.</param>
+    /// <returns>List of implementing types.</returns>
     public static List<Type> GetInterfaceTypes<T>(this Assembly asm)
     {
         var types = asm.GetTypes();
@@ -104,6 +151,11 @@ public static class ReflectionExtensions
         return types.Where(t => t.GetInterfaces().Contains(typeof(T)) && t.IsClass).ToList();
     }
 
+    /// <summary>
+    /// Gets all public properties or fields of the specified type.
+    /// </summary>
+    /// <param name="obj_type">Type to inspect.</param>
+    /// <returns>List of public properties or fields.</returns>
     public static List<PropertyInfo> GetPublicPropertiesOrFields(this Type obj_type)
     {
         List<PropertyInfo> members = [];
@@ -165,6 +217,11 @@ public static class ReflectionExtensions
         return prop;
     }
 
+    /// <summary>
+    /// Retrieves members of a type in declaration order, accounting for inheritance.
+    /// </summary>
+    /// <param name="instanceType">Type to inspect.</param>
+    /// <returns>Ordered enumeration of members.</returns>
     public static IOrderedEnumerable<MemberInfo> GetMembersInDeclarationOrder(this Type instanceType)
     {
         ArgumentNullException.ThrowIfNull(instanceType);
@@ -193,6 +250,11 @@ public static class ReflectionExtensions
 
     private static readonly ConcurrentDictionary<string, IOrderedEnumerable<MemberInfo>> _classMembers = new();
 
+    /// <summary>
+    /// Retrieves instance members, caching results for reuse.
+    /// </summary>
+    /// <param name="instance_type">Type to inspect.</param>
+    /// <returns>Ordered enumeration of members.</returns>
     public static IOrderedEnumerable<MemberInfo> GetAndCacheInstanceMembers(this Type instance_type)
     {
         string instance_typename = instance_type.ToString();

--- a/MicroM/core/Extensions/StringExtensions.cs
+++ b/MicroM/core/Extensions/StringExtensions.cs
@@ -2,12 +2,24 @@
 
 public static class StringExtensions
 {
+    /// <summary>
+    /// Truncates the string to the specified maximum length.
+    /// </summary>
+    /// <param name="value">Source string.</param>
+    /// <param name="maxLength">Maximum length.</param>
+    /// <returns>Truncated string.</returns>
     public static string Truncate(this string value, int maxLength)
     {
         if (string.IsNullOrEmpty(value)) return value;
         return value[..(value.Length > maxLength ? maxLength : value.Length)];
     }
 
+    /// <summary>
+    /// Removes surrounding quotes from a string and optionally unescapes inner quotes.
+    /// </summary>
+    /// <param name="value">String to process.</param>
+    /// <param name="unescape">Whether to unescape double quotes.</param>
+    /// <returns>Unquoted string.</returns>
     public static string Unquote(this string value, bool unescape = false)
     {
         if (string.IsNullOrWhiteSpace(value) || value.Length < 2)
@@ -28,27 +40,54 @@ public static class StringExtensions
         return value;
     }
 
+    /// <summary>
+    /// Removes surrounding quotes from each string in the collection.
+    /// </summary>
+    /// <param name="value">Collection of strings.</param>
+    /// <returns>Collection of unquoted strings.</returns>
     public static IEnumerable<string> Unquote(this IEnumerable<string> value)
     {
         return value.Select(x => x.Unquote()).ToArray();
     }
 
+    /// <summary>
+    /// Trims whitespace from each string in the collection.
+    /// </summary>
+    /// <param name="value">Collection of strings.</param>
+    /// <returns>Collection of trimmed strings.</returns>
     public static IEnumerable<string> Trim(this IEnumerable<string> value)
     {
         return value.Select(x => x.Trim()).ToArray();
     }
 
+    /// <summary>
+    /// Returns a fallback value when the string is null or empty.
+    /// </summary>
+    /// <param name="value">Source string.</param>
+    /// <param name="null_or_empty_value">Value returned when source is null or empty.</param>
+    /// <returns>Original or fallback value.</returns>
     public static string IfNullOrEmpty(this string value, string null_or_empty_value)
     {
         return string.IsNullOrEmpty(value) ? null_or_empty_value : value;
     }
 
+    /// <summary>
+    /// Throws an exception if the string is null or empty.
+    /// </summary>
+    /// <param name="value">String to validate.</param>
+    /// <param name="parm_name">Parameter name for the exception.</param>
+    /// <returns>The original string.</returns>
     public static string ThrowIfNullOrEmpty(this string value, string? parm_name)
     {
         if (string.IsNullOrEmpty(value)) throw new ArgumentNullException(parm_name);
         return value;
     }
 
+    /// <summary>
+    /// Determines whether the string is null or empty.
+    /// </summary>
+    /// <param name="value">String to check.</param>
+    /// <returns><c>true</c> if null or empty.</returns>
     public static bool IsNullOrEmpty(this string? value)
     {
         return string.IsNullOrEmpty(value);

--- a/MicroM/core/Extensions/TimeExtensions.cs
+++ b/MicroM/core/Extensions/TimeExtensions.cs
@@ -2,6 +2,11 @@
 {
     public static class TimeExtensions
     {
+        /// <summary>
+        /// Formats a <see cref="TimeSpan"/> into a human-readable duration string.
+        /// </summary>
+        /// <param name="duration">Duration to format.</param>
+        /// <returns>Human-friendly duration text.</returns>
         public static string ToHumanDuration(this TimeSpan duration)
         {
             if (duration.TotalDays >= 1)

--- a/MicroM/core/Extensions/ViewExtensions.cs
+++ b/MicroM/core/Extensions/ViewExtensions.cs
@@ -4,6 +4,11 @@ namespace MicroM.Extensions
 {
     public static class ViewExtensions
     {
+        /// <summary>
+        /// Converts view parameters to their underlying column definitions.
+        /// </summary>
+        /// <param name="parms">View parameters.</param>
+        /// <returns>Enumeration of column definitions.</returns>
         public static IEnumerable<ColumnBase> ToColumnBaseEnumerable(this Dictionary<string, ViewParm> parms)
         {
             List<ColumnBase> ret = [];
@@ -16,6 +21,13 @@ namespace MicroM.Extensions
             return ret;
         }
 
+        /// <summary>
+        /// Filters a column dictionary by included or excluded names.
+        /// </summary>
+        /// <param name="parms">Source columns.</param>
+        /// <param name="include">Names to include.</param>
+        /// <param name="exclude">Names to exclude.</param>
+        /// <returns>Filtered column sequence.</returns>
         public static IEnumerable<ColumnBase> FilterByName(this Dictionary<string, ColumnBase> parms, string[]? include = null, string[]? exclude = null)
         {
             List<ColumnBase> ret = [];


### PR DESCRIPTION
## Summary
- add XML documentation to all extension methods in MicroM core
- ensure extension docs list all public members
- mark MicroM.Extensions backend docs as complete

## Testing
- `dotnet test` *(fails: /workspace/MicroMFramework/MicroM/core/MicroMCore.csproj(180,5): error MSB3073: The command "del /Q "bin/Debug/*.nupkg"" exited with code 127.)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e959b6548324ab17419e88669a5d