### PR TITLE
Document MicroM.Database namespace

### DIFF
--- a/MicroM/Documentation-Progress/Backend/docs-state-backend.md
+++ b/MicroM/Documentation-Progress/Backend/docs-state-backend.md
@@ -43,8 +43,8 @@ This file tracks the current documentation state of the backend (`/MicroM/core`)
 - Notes: Namespace index documented; class pages and XML comments pending.
 
 ### MicroM.Database
-- State: Incomplete ⚠️
-- Notes: Namespace and classes documented; XML comments pending.
+ - State: Complete ✅
+ - Notes: Namespace and all public types documented with XML comments and pages.
 
 ### MicroM.Excel
 - State: Complete ✅

--- a/MicroM/Documentation-Progress/Backend/iteration-summary.md
+++ b/MicroM/Documentation-Progress/Backend/iteration-summary.md
@@ -434,3 +434,28 @@
 - Continue documenting remaining `MicroM.Data` types.
 - Add XML comments for web services and controllers.
 - Expand documentation with method details and examples.
+
+---
+
+## Iteration 16
+### Plan
+- Add XML comments for all public members under `MicroM/core/Database`.
+- Document enums `SQLScriptType` and `SQLProcStandardType`.
+- Link enums in `MicroM/Documentation/Backend/MicroM.Database/index.md`.
+- Update documentation state for `MicroM.Database`.
+
+### Execution Results
+- Added XML comments to database classes and methods → ✅ Success
+- Created enum docs under `MicroM.Database` and linked from namespace index → ✅ Success
+- Updated `docs-state-backend.md` marking `MicroM.Database` as complete → ✅ Success
+
+### Verification Results
+- Verified XML comments in updated source files → ✅ Success
+- Confirmed enum pages follow template and are linked → ✅ Success
+- `docs-state-backend.md` shows completed status → ✅ Success
+
+### Issues Encountered
+- None
+
+### Next iteration Tasks
+- Review remaining namespaces for XML comments and documentation gaps.

--- a/MicroM/Documentation/Backend/MicroM.Database/SQLProcStandardType/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Database/SQLProcStandardType/index.md
@@ -1,0 +1,21 @@
+# Enum: MicroM.Database.SQLProcStandardType
+## Overview
+Standard categories for generated procedures.
+
+## Members
+| Member | Description |
+|:------------|:-------------|
+| Update | Update procedure. |
+| Get | Get procedure. |
+| Lookup | Lookup procedure. |
+| StandardView | Standard view. |
+| Drop | Drop procedure. |
+| IDrop | Installation drop script. |
+| IUpdate | Installation update script. |
+| Unknown | Unknown procedure type. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Database/SQLScriptType/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Database/SQLScriptType/index.md
@@ -1,0 +1,21 @@
+# Enum: MicroM.Database.SQLScriptType
+## Overview
+Types of SQL scripts supported by MicroM.
+
+## Members
+| Member | Description |
+|:------------|:-------------|
+| Procedure | Stored procedure. |
+| Function | Function definition. |
+| Type | User defined type. |
+| Sequence | Sequence definition. |
+| View | View definition. |
+| Trigger | Trigger definition. |
+| Table | Table creation script. |
+| Unknown | Unknown script type. |
+
+## Remarks
+None.
+
+## See Also
+-

--- a/MicroM/Documentation/Backend/MicroM.Database/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Database/index.md
@@ -21,8 +21,8 @@ Database utilities and schema management.
 ## Enums
 | Enum | Description |
 |:------------|:-------------|
-| SQLScriptType | Type of SQL scripts. |
-| SQLProcStandardType | Standard procedure categories. |
+| [SQLScriptType](SQLScriptType/index.md) | Type of SQL scripts. |
+| [SQLProcStandardType](SQLProcStandardType/index.md) | Standard procedure categories. |
 
 ## Remarks
 None.

--- a/MicroM/core/Database/ApplicationDatabase.cs
+++ b/MicroM/core/Database/ApplicationDatabase.cs
@@ -11,6 +11,9 @@ using static MicroM.Validators.Expressions;
 
 namespace MicroM.Database
 {
+    /// <summary>
+    /// Provides helpers to create and manage application databases.
+    /// </summary>
     public class ApplicationDatabase
     {
         private static async Task InitializeDatabase(IEntityClient admin_dbc, Applications app, string grant_user, CancellationToken ct)
@@ -76,6 +79,14 @@ namespace MicroM.Database
         }
 
 
+        /// <summary>
+        /// Retrieves and updates the status of the application's database.
+        /// </summary>
+        /// <param name="app">The application instance.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <param name="options">Optional MicroM options.</param>
+        /// <param name="server_claims">Server credentials.</param>
+        /// <param name="api">Optional API services.</param>
         public static async Task GetAppDatabaseStatus(Applications app, CancellationToken ct, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null)
         {
             ArgumentNullException.ThrowIfNull(server_claims);
@@ -106,6 +117,14 @@ namespace MicroM.Database
             }
         }
 
+        /// <summary>
+        /// Drops the application's database and associated login.
+        /// </summary>
+        /// <param name="app">The application definition.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <param name="options">Optional MicroM options.</param>
+        /// <param name="server_claims">Server credentials.</param>
+        /// <param name="api">Optional API services.</param>
         public static async Task DropAppDatabase(Applications app, CancellationToken ct, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null)
         {
             ArgumentNullException.ThrowIfNull(server_claims);
@@ -124,12 +143,15 @@ namespace MicroM.Database
         }
 
         /// <summary>
-        /// Creates a new database for the application. It will use the app existing connection
+        /// Creates a new database for the application using its configuration.
         /// </summary>
-        /// <param name="app"></param>
-        /// <param name="drop_and_recreate"></param>
-        /// <param name="ct"></param>
-        /// <returns></returns>
+        /// <param name="app">Application definition.</param>
+        /// <param name="drop_and_recreate">If true, an existing database is dropped and recreated.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <param name="options">Optional MicroM options.</param>
+        /// <param name="server_claims">Server credentials.</param>
+        /// <param name="api">Optional API services.</param>
+        /// <returns>Status of the database creation.</returns>
         public static async Task<DBStatusResult> CreateAppDatabase(Applications app, bool drop_and_recreate, CancellationToken ct, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null)
         {
 
@@ -237,6 +259,15 @@ namespace MicroM.Database
             return new() { Results = [new() { Status = DBStatusCodes.OK }] };
         }
 
+        /// <summary>
+        /// Updates the application's database schema and data.
+        /// </summary>
+        /// <param name="app">The application instance.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <param name="server_claims">Server credentials.</param>
+        /// <param name="options">Optional MicroM options.</param>
+        /// <param name="api">Optional API services.</param>
+        /// <returns>Status of the update operation.</returns>
         public static async Task<DBStatusResult> UpdateAppDatabase(Applications app, CancellationToken ct, Dictionary<string, object>? server_claims = null, MicroMOptions? options = null, IWebAPIServices? api = null)
         {
             ArgumentNullException.ThrowIfNull(server_claims);

--- a/MicroM/core/Database/ConfigurationDatabaseSchema.cs
+++ b/MicroM/core/Database/ConfigurationDatabaseSchema.cs
@@ -6,9 +6,17 @@ using static MicroM.Database.DataDictionarySchema;
 
 namespace MicroM.Database;
 
+/// <summary>
+/// Helpers to build schema and procedures for the configuration database.
+/// </summary>
 public static class ConfigurationDatabaseSchema
 {
 
+    /// <summary>
+    /// Retrieves all entities required for the configuration database.
+    /// </summary>
+    /// <param name="ec">Entity client.</param>
+    /// <returns>Collection of entities with creation options.</returns>
     public static CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> GetConfigurationEntitiesTypes(IEntityClient ec)
     {
         CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> result = GetDataDictionaryEntitiesTypes(ec);
@@ -30,6 +38,14 @@ public static class ConfigurationDatabaseSchema
     }
 
 
+    /// <summary>
+    /// Creates configuration database schema and related stored procedures.
+    /// </summary>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="entities">Entities to include in the configuration database.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="create_or_alter">If true, existing objects are altered instead of created.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     public async static Task CreateConfigurationDBSchemaAndProcs(IEntityClient ec, CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> entities, CancellationToken ct, bool create_or_alter = false)
     {
         bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);

--- a/MicroM/core/Database/CustomScript.cs
+++ b/MicroM/core/Database/CustomScript.cs
@@ -1,28 +1,58 @@
 ﻿namespace MicroM.Database;
 
+/// <summary>
+/// Types of SQL scripts supported by MicroM.
+/// </summary>
 public enum SQLScriptType
 {
+    /// <summary>Stored procedure.</summary>
     Procedure,
+    /// <summary>Function definition.</summary>
     Function,
+    /// <summary>User defined type.</summary>
     Type,
+    /// <summary>Sequence definition.</summary>
     Sequence,
+    /// <summary>View definition.</summary>
     View,
+    /// <summary>Trigger definition.</summary>
     Trigger,
+    /// <summary>Table creation script.</summary>
     Table,
+    /// <summary>Unknown script type.</summary>
     Unknown
 }
 
+/// <summary>
+/// Standard categories for generated procedures.
+/// </summary>
 public enum SQLProcStandardType
 {
+    /// <summary>Update procedure.</summary>
     Update,
+    /// <summary>Get procedure.</summary>
     Get,
+    /// <summary>Lookup procedure.</summary>
     Lookup,
+    /// <summary>Standard view.</summary>
     StandardView,
+    /// <summary>Drop procedure.</summary>
     Drop,
+    /// <summary>Installation drop script.</summary>
     IDrop,
+    /// <summary>Installation update script.</summary>
     IUpdate,
+    /// <summary>Unknown procedure type.</summary>
     Unknown
 }
 
+/// <summary>
+/// Represents a custom SQL script and its classification.
+/// </summary>
+/// <param name="ProcName">Name of the procedure or object.</param>
+/// <param name="mneo">Associated mnemonic.</param>
+/// <param name="ProcType">Type of script.</param>
+/// <param name="StandardType">Standard procedure category.</param>
+/// <param name="SQLText">SQL text of the script.</param>
 public record CustomScript(string? ProcName, string? mneo, SQLScriptType ProcType, SQLProcStandardType StandardType, string SQLText);
 

--- a/MicroM/core/Database/DabataseSchema.cs
+++ b/MicroM/core/Database/DabataseSchema.cs
@@ -9,9 +9,24 @@ using static MicroM.Database.DatabaseSchemaTables;
 
 namespace MicroM.Database;
 
+/// <summary>
+/// Utilities to create schemas, tables, and procedures for entity models.
+/// </summary>
 public static class DatabaseSchema
 {
 
+    /// <summary>
+    /// Creates the schema, tables and procedures for an entity.
+    /// </summary>
+    /// <typeparam name="T">Entity type.</typeparam>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="create_or_alter">Whether to create or alter existing objects.</param>
+    /// <param name="create_if_not_exists">Only create if the table does not exist.</param>
+    /// <param name="create_custom_procs">Create custom procedures.</param>
+    /// <param name="drop_and_recreate_indexes">Drop and recreate indexes.</param>
+    /// <param name="create_procs">Create generated procedures.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The initialized entity instance.</returns>
     public static async Task<T> CreateSchema<T>(
         IEntityClient ec,
         bool create_or_alter, bool create_if_not_exists, bool create_custom_procs, bool drop_and_recreate_indexes,
@@ -80,6 +95,15 @@ public static class DatabaseSchema
         return ent;
     }
 
+    /// <summary>
+    /// Creates stored procedures for all provided entities and custom scripts.
+    /// </summary>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="entities">Entities for which to create procedures.</param>
+    /// <param name="classified_custom_scripts">Classified custom SQL scripts.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="create_or_alter">Create or alter existing procedures.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     public async static Task CreateAllEntitiesProcs(IEntityClient ec, CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> entities, CustomOrderedDictionary<CustomScript>? classified_custom_scripts, CancellationToken ct, bool create_or_alter = true)
     {
         bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -176,6 +200,14 @@ public static class DatabaseSchema
         }
     }
 
+    /// <summary>
+    /// Creates tables, constraints and procedures for entities and updates the data dictionary.
+    /// </summary>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="entities">Entities to process.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="create_or_alter">Create or alter existing objects.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     public async static Task CreateEntitiesDatabaseSchemaAndDictionary(IEntityClient ec, CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> entities, CancellationToken ct, bool create_or_alter = false)
     {
         bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);

--- a/MicroM/core/Database/DataDictionarySchema.cs
+++ b/MicroM/core/Database/DataDictionarySchema.cs
@@ -12,10 +12,19 @@ using static MicroM.Database.DatabaseSchemaTables;
 
 namespace MicroM.Database;
 
+/// <summary>
+/// Utilities for maintaining the MicroM data dictionary schema and permissions.
+/// </summary>
 public static class DataDictionarySchema
 {
 
 
+    /// <summary>
+    /// Adds the specified entity type to the data dictionary tables.
+    /// </summary>
+    /// <typeparam name="T">Entity type.</typeparam>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="ct">Cancellation token.</param>
     public static async Task AddToDataDictionary<T>(IEntityClient ec, CancellationToken ct) where T : EntityBase, new()
     {
         bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -31,6 +40,12 @@ public static class DataDictionarySchema
         }
     }
 
+    /// <summary>
+    /// Adds multiple entities to the data dictionary tables.
+    /// </summary>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="options">Entity creation options.</param>
+    /// <param name="ct">Cancellation token.</param>
     public static async Task AddEntitiesToDataDictionary(IEntityClient ec, CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> options, CancellationToken ct)
     {
         bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -48,6 +63,11 @@ public static class DataDictionarySchema
         }
     }
 
+    /// <summary>
+    /// Retrieves entity types that compose the core data dictionary.
+    /// </summary>
+    /// <param name="ec">Entity client.</param>
+    /// <returns>Dictionary of data dictionary entities.</returns>
     public static CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> GetDataDictionaryEntitiesTypes(IEntityClient ec)
     {
         CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> result = new();
@@ -89,6 +109,12 @@ public static class DataDictionarySchema
         return result;
     }
 
+    /// <summary>
+    /// Creates data dictionary tables, procedures and required categories.
+    /// </summary>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="create_or_alter">Indicates if existing objects should be altered.</param>
     public async static Task CreateDatadictionarySchemaAndProcs(IEntityClient ec, CancellationToken ct, bool create_or_alter = false)
     {
         bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -142,6 +168,10 @@ public static class DataDictionarySchema
         }
     }
 
+    /// <summary>
+    /// Gets the core entity types used by the framework.
+    /// </summary>
+    /// <returns>Dictionary of entity names and types.</returns>
     public static Dictionary<string, Type> GetCoreEntitiesTypes()
     {
         Dictionary<string, Type> result = [];
@@ -183,6 +213,12 @@ public static class DataDictionarySchema
         return result;
     }
 
+    /// <summary>
+    /// Grants execution permissions to system procedures for the specified login or group.
+    /// </summary>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="login_or_group">Login or group receiving permissions.</param>
+    /// <param name="ct">Cancellation token.</param>
     public async static Task GrantPermissionsToSystemProcs(IEntityClient ec, string login_or_group, CancellationToken ct)
     {
         CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> entities = GetDataDictionaryEntitiesTypes(ec);
@@ -217,6 +253,18 @@ public static class DataDictionarySchema
         return await sst.AddStatus(ec, ct);
     }
 
+    /// <summary>
+    /// Creates schema, procedures and data dictionary entries for the specified entity.
+    /// </summary>
+    /// <typeparam name="T">Entity type.</typeparam>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="create_or_alter">Create or alter existing objects.</param>
+    /// <param name="create_if_not_exists">Only create if not present.</param>
+    /// <param name="create_custom_procs">Whether to include custom procedures.</param>
+    /// <param name="drop_and_recreate_indexes">Drop and recreate indexes.</param>
+    /// <param name="create_procs">Whether to create generated procedures.</param>
+    /// <returns>The entity after creation.</returns>
     public static async Task<T> CreateSchemaAndDictionary<T>(
         IEntityClient ec, CancellationToken ct, bool create_or_alter = false, bool create_if_not_exists = true,
         bool create_custom_procs = false, bool drop_and_recreate_indexes = false, bool create_procs = true

--- a/MicroM/core/Database/DatabaseManagement.cs
+++ b/MicroM/core/Database/DatabaseManagement.cs
@@ -2,28 +2,64 @@
 
 namespace MicroM.Database;
 
+/// <summary>
+/// Utilities for SQL Server database management tasks.
+/// </summary>
 public static class DatabaseManagement
 {
+    /// <summary>
+    /// Determines whether the current connection has administrative rights.
+    /// </summary>
+    /// <param name="dbc">Database client.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns><c>true</c> if the user is a sysadmin; otherwise, <c>false</c>.</returns>
     public async static Task<bool> LoggedInUserHasAdminRights(IEntityClient dbc, CancellationToken ct)
     {
         return await dbc.ExecuteSQLSingleColumn<int?>("select is_srvrolemember('sysadmin')", ct) == 1;
     }
 
+    /// <summary>
+    /// Checks whether a SQL login exists on the server.
+    /// </summary>
+    /// <param name="dbc">Database client.</param>
+    /// <param name="sql_user">Login name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns><c>true</c> if the login exists.</returns>
     public async static Task<bool> UserExists(IEntityClient dbc, string sql_user, CancellationToken ct)
     {
         return await dbc.ExecuteSQLSingleColumn<int?>($"select suser_id('{sql_user ?? ""}')", ct) != null;
     }
 
+    /// <summary>
+    /// Checks if a database exists on the server.
+    /// </summary>
+    /// <param name="dbc">Database client.</param>
+    /// <param name="sql_database">Database name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns><c>true</c> if the database exists.</returns>
     public async static Task<bool> DatabaseExists(IEntityClient dbc, string sql_database, CancellationToken ct)
     {
         return await dbc.ExecuteSQLSingleColumn<int?>($"select convert(int,db_id('{sql_database ?? ""}'))", ct) != null;
     }
 
+    /// <summary>
+    /// Tests if the server is reachable and accepting connections.
+    /// </summary>
+    /// <param name="dbc">Database client.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns><c>true</c> if the connection succeeds.</returns>
     public async static Task<bool> ServerIsUp(IEntityClient dbc, CancellationToken ct)
     {
         return await dbc.Connect(ct);
     }
 
+    /// <summary>
+    /// Creates a database with the specified name and collation.
+    /// </summary>
+    /// <param name="dbc">Database client.</param>
+    /// <param name="database_name">Name of the database.</param>
+    /// <param name="database_collation">Optional collation.</param>
+    /// <param name="ct">Cancellation token.</param>
     public async static Task CreateDatabase(IEntityClient dbc, string database_name, string? database_collation, CancellationToken ct)
     {
         using IEntityClient ec = dbc.Clone();
@@ -42,6 +78,12 @@ public static class DatabaseManagement
         }
     }
 
+    /// <summary>
+    /// Drops the specified database if it exists.
+    /// </summary>
+    /// <param name="dbc">Database client.</param>
+    /// <param name="database_name">Database name.</param>
+    /// <param name="ct">Cancellation token.</param>
     public static async Task DropDatabase(IEntityClient dbc, string database_name, CancellationToken ct)
     {
         using IEntityClient ec = dbc.Clone();
@@ -58,6 +100,14 @@ public static class DatabaseManagement
         }
     }
 
+    /// <summary>
+    /// Creates a login and database user with the supplied password.
+    /// </summary>
+    /// <param name="dbc">Database client.</param>
+    /// <param name="database_name">Database to associate.</param>
+    /// <param name="login_name">Login name.</param>
+    /// <param name="password">Password.</param>
+    /// <param name="ct">Cancellation token.</param>
     public static async Task CreateLoginAndDatabaseUser(IEntityClient dbc, string database_name, string login_name, string password, CancellationToken ct)
     {
         using IEntityClient ec = dbc.Clone();
@@ -75,6 +125,12 @@ public static class DatabaseManagement
         }
     }
 
+    /// <summary>
+    /// Drops a SQL login from the server.
+    /// </summary>
+    /// <param name="dbc">Database client.</param>
+    /// <param name="login_name">Login name.</param>
+    /// <param name="ct">Cancellation token.</param>
     public static async Task DropLogin(IEntityClient dbc, string login_name, CancellationToken ct)
     {
         using IEntityClient ec = dbc.Clone();
@@ -90,6 +146,14 @@ public static class DatabaseManagement
         }
     }
 
+    /// <summary>
+    /// Determines if a table exists in the specified schema.
+    /// </summary>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="table_name">Table name.</param>
+    /// <param name="schema_name">Schema name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns><c>true</c> if the table exists.</returns>
     public static async Task<bool> TableExists(IEntityClient ec, string table_name, string schema_name, CancellationToken ct)
     {
         string query = $"SELECT count(*) FROM information_schema.tables WHERE table_schema = '{schema_name}' AND table_name = '{table_name}'";

--- a/MicroM/core/Database/DatabaseSchemaCreationOptions.cs
+++ b/MicroM/core/Database/DatabaseSchemaCreationOptions.cs
@@ -2,11 +2,20 @@
 
 namespace MicroM.Database
 {
+    /// <summary>
+    /// Options used when generating database schema for an entity.
+    /// </summary>
+    /// <typeparam name="T">Entity type.</typeparam>
+    /// <param name="EntityInstance">Instance of the entity.</param>
+    /// <param name="create_or_alter">Indicates if existing objects should be altered.</param>
     public record DatabaseSchemaCreationOptions<T>(T EntityInstance, bool create_or_alter = true) where T : EntityBase
     {
+        /// <summary>Type of the entity.</summary>
         public Type EntityType => EntityInstance.GetType();
+        /// <summary>Mnemonic of the entity.</summary>
         public string Mneo => EntityInstance.Def.Mneo;
 
+        /// <summary>Gets or sets a value indicating whether to create or alter existing objects.</summary>
         public bool create_or_alter { get; set; } = create_or_alter;
     }
 }

--- a/MicroM/core/Database/DatabaseSchemaCustomScripts.cs
+++ b/MicroM/core/Database/DatabaseSchemaCustomScripts.cs
@@ -5,8 +5,16 @@ using static MicroM.Data.SystemStandardProceduresSuffixs;
 
 namespace MicroM.Database;
 
+/// <summary>
+/// Helpers to parse and classify custom SQL scripts embedded in assemblies.
+/// </summary>
 public static partial class DatabaseSchemaCustomScripts
 {
+    /// <summary>
+    /// Extracts basic information from a SQL script and classifies it.
+    /// </summary>
+    /// <param name="sql_text">SQL script text.</param>
+    /// <returns>The classified script or <c>null</c> if not recognized.</returns>
     public static CustomScript? ExtractCustomScript(string sql_text)
     {
         if (string.IsNullOrWhiteSpace(sql_text))
@@ -142,6 +150,11 @@ public static partial class DatabaseSchemaCustomScripts
     [GeneratedRegex(@"^\s*GO\s*(?:\r?\n|$)", RegexOptions.Multiline | RegexOptions.IgnoreCase)]
     private static partial Regex SplitSQLScriptsRegex();
 
+    /// <summary>
+    /// Splits and classifies a SQL script into individual custom scripts.
+    /// </summary>
+    /// <param name="sql_script">Combined SQL script.</param>
+    /// <returns>Enumerated custom scripts.</returns>
     public static IEnumerable<CustomScript> ClassifyCustomSQLScript(string sql_script)
     {
 
@@ -158,6 +171,11 @@ public static partial class DatabaseSchemaCustomScripts
         }
     }
 
+    /// <summary>
+    /// Classifies a list of SQL scripts into custom script objects.
+    /// </summary>
+    /// <param name="sql_scripts">Collection of SQL scripts.</param>
+    /// <returns>Dictionary of classified custom scripts.</returns>
     public static CustomOrderedDictionary<CustomScript> ClassifyCustomSQLScripts(List<string> sql_scripts)
     {
         CustomOrderedDictionary<CustomScript> procs = new();

--- a/MicroM/core/Database/DatabaseSchemaExtensions.cs
+++ b/MicroM/core/Database/DatabaseSchemaExtensions.cs
@@ -5,9 +5,19 @@ using System.Reflection;
 
 namespace MicroM.Database
 {
+    /// <summary>
+    /// Extension methods for building database schemas from entities and assemblies.
+    /// </summary>
     public static class DatabaseSchemaExtensions
     {
 
+        /// <summary>
+        /// Adds the specified entity type to the dictionary if it does not exist.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="dict">Dictionary of creation options.</param>
+        /// <param name="ec">Entity client.</param>
+        /// <param name="create_or_alter">Indicates if objects should be created or altered.</param>
         public static void TryAddEntityType<T>(this CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> dict, IEntityClient ec, bool create_or_alter = true) where T : EntityBase, new()
         {
             var ent = new T();
@@ -22,6 +32,12 @@ namespace MicroM.Database
             );
         }
 
+        /// <summary>
+        /// Adds the provided entity instances to the dictionary if they do not exist.
+        /// </summary>
+        /// <param name="dict">Dictionary of creation options.</param>
+        /// <param name="create_or_alter">Indicates if objects should be created or altered.</param>
+        /// <param name="entities">Entities to add.</param>
         public static void TryAddEntities(this CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> dict, bool create_or_alter = true, params EntityBase[] entities)
         {
             foreach (var entity in entities)
@@ -36,6 +52,12 @@ namespace MicroM.Database
             }
         }
 
+        /// <summary>
+        /// Retrieves and classifies all embedded SQL scripts in the assembly.
+        /// </summary>
+        /// <param name="assembly">Assembly to scan.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>Dictionary of classified custom scripts.</returns>
         public async static Task<CustomOrderedDictionary<CustomScript>> GetAllClassifiedCustomProcs(this Assembly assembly, CancellationToken ct)
         {
             CustomOrderedDictionary<CustomScript> ret = new();
@@ -62,6 +84,14 @@ namespace MicroM.Database
             return ret;
         }
 
+        /// <summary>
+        /// Creates a dictionary of all entity types contained in the assembly.
+        /// </summary>
+        /// <param name="assembly">Assembly to scan.</param>
+        /// <param name="ec">Entity client.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <param name="create_or_alter">Indicates if objects should be created or altered.</param>
+        /// <returns>Dictionary of entity creation options.</returns>
         public static CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> GetAllEntities(this Assembly assembly, IEntityClient ec, CancellationToken ct, bool create_or_alter = true)
         {
             CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> ret = new();

--- a/MicroM/core/Database/DatabaseSchemaPermissions.cs
+++ b/MicroM/core/Database/DatabaseSchemaPermissions.cs
@@ -6,8 +6,18 @@ using System.Text;
 
 namespace MicroM.Database;
 
+/// <summary>
+/// Grants permissions and routes for database entities.
+/// </summary>
 public class DatabaseSchemaPermissions
 {
+    /// <summary>
+    /// Creates routing entries for the specified entities.
+    /// </summary>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="entities">Entities to process.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     public async static Task CreateEntitiesRoutes(IEntityClient ec, CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> entities, CancellationToken ct)
     {
         bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -26,6 +36,14 @@ public class DatabaseSchemaPermissions
         }
     }
 
+    /// <summary>
+    /// Grants execution rights on all entity procedures to the specified login or group.
+    /// </summary>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="entities">Entities whose procedures will be granted.</param>
+    /// <param name="login_or_group">Login or group receiving permissions.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     public async static Task GrantExecutionToAllProcs(IEntityClient ec, CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> entities, string login_or_group, CancellationToken ct)
     {
         bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);

--- a/MicroM/core/Database/DatabaseSchemaProcedures.cs
+++ b/MicroM/core/Database/DatabaseSchemaProcedures.cs
@@ -8,8 +8,18 @@ using static MicroM.Database.DatabaseSchemaCustomScripts;
 
 namespace MicroM.Database;
 
+/// <summary>
+/// Helpers for generating and executing database stored procedures.
+/// </summary>
 public static class DatabaseSchemaProcedures
 {
+    /// <summary>
+    /// Creates custom procedures defined for an entity.
+    /// </summary>
+    /// <typeparam name="T">Entity type.</typeparam>
+    /// <param name="ent">Optional initialized entity instance.</param>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="ct">Cancellation token.</param>
     public static async Task CreateCustomProcs<T>(T? ent, IEntityClient ec, CancellationToken ct) where T : EntityBase, new()
     {
         bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -38,6 +48,15 @@ public static class DatabaseSchemaProcedures
         }
     }
 
+    /// <summary>
+    /// Generates and executes standard procedures for an entity.
+    /// </summary>
+    /// <typeparam name="T">Entity type.</typeparam>
+    /// <param name="ent">Entity instance.</param>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="classified_custom_procs">Custom scripts that may replace generated procedures.</param>
+    /// <param name="create_or_alter">Indicates if procedures should be created or altered.</param>
     public static async Task CreateGeneratedProcs<T>(
         T ent,
         IEntityClient ec,
@@ -117,6 +136,15 @@ public static class DatabaseSchemaProcedures
 
     }
 
+    /// <summary>
+    /// Creates both generated and custom procedures for an entity.
+    /// </summary>
+    /// <typeparam name="T">Entity type.</typeparam>
+    /// <param name="ent">Entity instance.</param>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="create_or_alter">Indicates if procedures should be created or altered.</param>
+    /// <param name="create_custom_procs">Whether to include custom procedures.</param>
     public static async Task CreateProcs<T>(
         T ent,
         IEntityClient ec,
@@ -286,6 +314,16 @@ public static class DatabaseSchemaProcedures
 
     }
 
+    /// <summary>
+    /// Creates the schema and procedures for an entity and returns the initialized instance.
+    /// </summary>
+    /// <typeparam name="T">Entity type.</typeparam>
+    /// <param name="ent">Optional existing entity instance.</param>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="create_or_alter">Indicates if objects should be created or altered.</param>
+    /// <param name="create_custom_procs">Whether to include custom procedures.</param>
+    /// <returns>The entity after creation.</returns>
     public static async Task<T> CreateEntityAndProcs<T>(
     T? ent,
     IEntityClient ec,

--- a/MicroM/core/Database/DatabaseSchemaTables.cs
+++ b/MicroM/core/Database/DatabaseSchemaTables.cs
@@ -6,8 +6,18 @@ using static MicroM.Database.DatabaseManagement;
 
 namespace MicroM.Database
 {
+    /// <summary>
+    /// Helpers for creating tables, types and constraints for entity schemas.
+    /// </summary>
     public static class DatabaseSchemaTables
     {
+        /// <summary>
+        /// Returns the names of tables that do not exist for the given entities.
+        /// </summary>
+        /// <param name="ec">Entity client.</param>
+        /// <param name="entities">Entities to check.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>Set of table names that are missing.</returns>
         public static async Task<HashSet<string>> GetEntitiesInexistingTables(IEntityClient ec, CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> entities, CancellationToken ct)
         {
             bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -28,6 +38,13 @@ namespace MicroM.Database
             return inexisting_tables;
         }
 
+        /// <summary>
+        /// Creates tables for entities that are missing in the database.
+        /// </summary>
+        /// <param name="ec">Entity client.</param>
+        /// <param name="entities">Entities to process.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <returns>Dictionary of entities whose tables were created.</returns>
         public static async Task<CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>>> CreateEntitiesInexistentTables(IEntityClient ec, CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> entities, CancellationToken ct)
         {
             bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -68,6 +85,13 @@ namespace MicroM.Database
             }
         }
 
+        /// <summary>
+        /// Creates custom SQL types and sequences contained in the provided scripts.
+        /// </summary>
+        /// <param name="ec">Entity client.</param>
+        /// <param name="classified_custom_procs">Classified custom scripts.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <param name="create_or_alter">Indicates if existing objects should be altered.</param>
         public async static Task CreateAllCustomSQLTypes(IEntityClient ec, CustomOrderedDictionary<CustomScript>? classified_custom_procs, CancellationToken ct, bool create_or_alter = true)
         {
             bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -97,6 +121,13 @@ namespace MicroM.Database
             }
         }
 
+        /// <summary>
+        /// Creates custom tables defined in the classified scripts.
+        /// </summary>
+        /// <param name="ec">Entity client.</param>
+        /// <param name="classified_custom_procs">Classified custom scripts.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <param name="create_or_alter">Indicates if existing objects should be altered.</param>
         public async static Task CreateAllCustomTables(IEntityClient ec, CustomOrderedDictionary<CustomScript>? classified_custom_procs, CancellationToken ct, bool create_or_alter = true)
         {
             bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -119,6 +150,13 @@ namespace MicroM.Database
             }
         }
 
+        /// <summary>
+        /// Creates custom views defined in the classified scripts.
+        /// </summary>
+        /// <param name="ec">Entity client.</param>
+        /// <param name="classified_custom_procs">Classified custom scripts.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <param name="create_or_alter">Indicates if existing objects should be altered.</param>
         public async static Task CreateAllCustomViews(IEntityClient ec, CustomOrderedDictionary<CustomScript>? classified_custom_procs, CancellationToken ct, bool create_or_alter = true)
         {
             bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -141,6 +179,12 @@ namespace MicroM.Database
             }
         }
 
+        /// <summary>
+        /// Drops indexes for the specified entities.
+        /// </summary>
+        /// <param name="ec">Entity client.</param>
+        /// <param name="entities">Entity types.</param>
+        /// <param name="ct">Cancellation token.</param>
         public static async Task DropEntitiesIndexes(IEntityClient ec, Dictionary<string, Type> entities, CancellationToken ct)
         {
             bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -169,6 +213,12 @@ namespace MicroM.Database
             }
         }
 
+        /// <summary>
+        /// Creates indexes for the specified entities.
+        /// </summary>
+        /// <param name="ec">Entity client.</param>
+        /// <param name="entities">Entity types.</param>
+        /// <param name="ct">Cancellation token.</param>
         public static async Task CreateEntitiesIndexes(IEntityClient ec, Dictionary<string, Type> entities, CancellationToken ct)
         {
             bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -197,6 +247,13 @@ namespace MicroM.Database
             }
         }
 
+        /// <summary>
+        /// Drops constraints and indexes for the specified entities.
+        /// </summary>
+        /// <param name="ec">Entity client.</param>
+        /// <param name="entities">Entity types.</param>
+        /// <param name="ct">Cancellation token.</param>
+        /// <param name="drop_primary_keys">Whether to drop primary keys as well.</param>
         public static async Task DropEntitiesConstraintsAndIndexes(IEntityClient ec, Dictionary<string, Type> entities, CancellationToken ct, bool drop_primary_keys = false)
         {
             bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);
@@ -234,6 +291,12 @@ namespace MicroM.Database
             }
         }
 
+        /// <summary>
+        /// Creates constraints and indexes for the specified entities.
+        /// </summary>
+        /// <param name="ec">Entity client.</param>
+        /// <param name="entities">Entities to process.</param>
+        /// <param name="ct">Cancellation token.</param>
         public static async Task CreateEntitiesConstraintsAndIndexes(IEntityClient ec, CustomOrderedDictionary<DatabaseSchemaCreationOptions<EntityBase>> entities, CancellationToken ct)
         {
             bool should_close = !(ec.ConnectionState == System.Data.ConnectionState.Open);


### PR DESCRIPTION
## Summary
- document database utilities with comprehensive XML comments
- add enum docs for SQLScriptType and SQLProcStandardType and link in namespace index
- mark MicroM.Database as fully documented in docs-state

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: /usr/bin/sh: del: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e95920548324bc5b72bf0f993dfe