### PR TITLE
docs: extend DataDictionary coverage

### DIFF
--- a/MicroM/Documentation-Progress/Backend/docs-state-backend.md
+++ b/MicroM/Documentation-Progress/Backend/docs-state-backend.md
@@ -20,7 +20,7 @@ This file tracks the current documentation state of the backend (`/MicroM/core`)
 
 ### MicroM.DataDictionary
 - State: Incomplete ⚠️
-- Notes: Namespace index updated; application assembly and OIDC classes documented; remaining types require documentation.
+- Notes: Added documentation for ApplicationsUrls, FileStore, FileStoreProcess, FileStoreStatus and Numbering; other entities remain pending.
 
 ### MicroM.DataDictionary.CategoriesDefinitions
 - State: Complete ✅
@@ -39,8 +39,8 @@ This file tracks the current documentation state of the backend (`/MicroM/core`)
 - Notes: Namespace index with LoginResult, LoginAttemptResult, LoginAttemptStatus, LoginData, and RefreshTokenResult documented.
 
 ### MicroM.DataDictionary.StatusDefs
-- State: Incomplete ⚠️
-- Notes: Namespace index documented; class pages and XML comments pending.
+- State: Complete ✅
+- Notes: Status definitions documented with XML comments and pages.
 
 ### MicroM.Database
 - State: Incomplete ⚠️

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.StatusDefs/EmailStatus/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.StatusDefs/EmailStatus/index.md
@@ -1,0 +1,23 @@
+# Class: MicroM.DataDictionary.StatusDefs.EmailStatus
+## Overview
+Defines possible states for emails processed by the system.
+
+**Inheritance**
+StatusDefinition -> EmailStatus
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| EmailStatus() | Initializes a new instance. |
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| QUEUED | StatusValuesDefinition | Email is queued but not yet processed. |
+| PROCESSING | StatusValuesDefinition | Email is currently being processed. |
+| SENT | StatusValuesDefinition | Email was sent successfully. |
+| ERROR | StatusValuesDefinition | An error occurred while sending. |
+| RETRY | StatusValuesDefinition | Email failed and is pending retry. |
+
+## See Also
+- [StatusDefinition](../../MicroM.DataDictionary.Configuration/StatusDefinition/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.StatusDefs/FileUpload/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.StatusDefs/FileUpload/index.md
@@ -1,0 +1,23 @@
+# Class: MicroM.DataDictionary.StatusDefs.FileUpload
+## Overview
+Represents stages of a file upload operation.
+
+**Inheritance**
+StatusDefinition -> FileUpload
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| FileUpload() | Initializes a new instance. |
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| Pending | StatusValuesDefinition | Upload is queued but not started. |
+| Uploading | StatusValuesDefinition | Data is currently being transferred. |
+| Uploaded | StatusValuesDefinition | Upload completed successfully. |
+| Failed | StatusValuesDefinition | Upload failed due to an error. |
+| Cancelled | StatusValuesDefinition | Upload was cancelled before completion. |
+
+## See Also
+- [StatusDefinition](../../MicroM.DataDictionary.Configuration/StatusDefinition/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.StatusDefs/ImportStatus/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.StatusDefs/ImportStatus/index.md
@@ -1,0 +1,23 @@
+# Class: MicroM.DataDictionary.StatusDefs.ImportStatus
+## Overview
+Describes the progression of a data import task.
+
+**Inheritance**
+StatusDefinition -> ImportStatus
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ImportStatus() | Initializes a new instance. |
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| Pending | StatusValuesDefinition | Import has been queued but not started. |
+| FormatError | StatusValuesDefinition | The file format is invalid. |
+| Importing | StatusValuesDefinition | Import is currently running. |
+| Completed | StatusValuesDefinition | Import completed successfully. |
+| Error | StatusValuesDefinition | An unexpected error occurred during import. |
+
+## See Also
+- [StatusDefinition](../../MicroM.DataDictionary.Configuration/StatusDefinition/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.StatusDefs/ProcessStatus/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.StatusDefs/ProcessStatus/index.md
@@ -1,0 +1,20 @@
+# Class: MicroM.DataDictionary.StatusDefs.ProcessStatus
+## Overview
+Basic start and completion flags for a process.
+
+**Inheritance**
+StatusDefinition -> ProcessStatus
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ProcessStatus() | Initializes a new instance. |
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| Started | StatusValuesDefinition | Process has started. |
+| Completed | StatusValuesDefinition | Process finished successfully. |
+
+## See Also
+- [StatusDefinition](../../MicroM.DataDictionary.Configuration/StatusDefinition/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationsUrls/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationsUrls/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.DataDictionary.ApplicationsUrls
+## Overview
+Runtime entity for interacting with application URL records.
+
+**Inheritance**
+Entity<ApplicationsUrlsDef> -> ApplicationsUrls
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ApplicationsUrls() | Initializes a new instance. |
+| ApplicationsUrls(IEntityClient ec, IMicroMEncryption? encryptor = null) | Initializes with a database client and optional encryptor. |
+
+## See Also
+- [ApplicationsUrlsDef](../ApplicationsUrlsDef/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationsUrlsDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/ApplicationsUrlsDef/index.md
@@ -1,0 +1,24 @@
+# Class: MicroM.DataDictionary.ApplicationsUrlsDef
+## Overview
+Schema definition for storing application URLs.
+
+**Inheritance**
+EntityDefinition -> ApplicationsUrlsDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ApplicationsUrlsDef() | Initializes a new instance. |
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| c_application_id | Column<string> | Identifier of the application. |
+| c_application_url_id | Column<string> | Unique identifier for the application URL. |
+| vc_application_url | Column<string> | URL value. |
+| apu_brwStandard | ViewDefinition | Default browse view for application URLs. |
+| FKApplicationsUrls | EntityForeignKey<Applications, ApplicationsUrls> | Relationship to application entity. |
+| UNApplicationUrl | EntityUniqueConstraint | Ensures uniqueness of URLs per application. |
+
+## See Also
+- [ApplicationsUrls](../ApplicationsUrls/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/FileStore/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/FileStore/index.md
@@ -1,0 +1,16 @@
+# Class: MicroM.DataDictionary.FileStore
+## Overview
+Runtime entity for managing stored file records.
+
+**Inheritance**
+Entity<FileStoreDef> -> FileStore
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| FileStore() | Initializes a new instance. |
+| FileStore(IEntityClient ec, IMicroMEncryption? encryptor = null) | Initializes with a database client and optional encryptor. |
+
+## See Also
+- [FileStoreDef](../FileStoreDef/index.md)
+- [FileStoreProcess](../FileStoreProcess/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/FileStoreDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/FileStoreDef/index.md
@@ -1,0 +1,31 @@
+# Class: MicroM.DataDictionary.FileStoreDef
+## Overview
+Schema definition for persisted files.
+
+**Inheritance**
+EntityDefinition -> FileStoreDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| FileStoreDef() | Initializes a new instance. |
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| c_file_id | Column<string> | Primary identifier of the stored file. |
+| c_fileprocess_id | Column<string> | Identifier of the generating process. |
+| vc_filename | Column<string> | File name. |
+| vc_filefolder | Column<string> | Folder used for storage. |
+| vc_fileguid | Column<string> | Unique file GUID. |
+| bi_filesize | Column<long> | File size in bytes. |
+| c_fileuploadstatus_id | Column<string> | Status identifier tracking upload progress. |
+| fst_brwStandard | ViewDefinition | Default browse view by file ID. |
+| fst_brwFiles | ViewDefinition | Browse view for retrieving files by process. |
+| fst_getByGUID | ProcedureDefinition | Retrieves a file by its GUID. |
+| FKFileStoreProcess | EntityForeignKey<FileStoreProcess, FileStore> | Link to the creating process. |
+| UCFileStore | EntityUniqueConstraint | Enforces unique GUID values. |
+
+## See Also
+- [FileStore](../FileStore/index.md)
+- [FileStoreProcess](../FileStoreProcess/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/FileStoreProcess/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/FileStoreProcess/index.md
@@ -1,0 +1,16 @@
+# Class: MicroM.DataDictionary.FileStoreProcess
+## Overview
+Runtime entity representing a file storage process.
+
+**Inheritance**
+Entity<FileStoreProcessDef> -> FileStoreProcess
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| FileStoreProcess() | Initializes a new instance. |
+| FileStoreProcess(IEntityClient ec, IMicroMEncryption? encryptor = null) | Initializes with a database client and optional encryptor. |
+
+## See Also
+- [FileStoreProcessDef](../FileStoreProcessDef/index.md)
+- [FileStore](../FileStore/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/FileStoreProcessDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/FileStoreProcessDef/index.md
@@ -1,0 +1,20 @@
+# Class: MicroM.DataDictionary.FileStoreProcessDef
+## Overview
+Schema definition for file storage processes.
+
+**Inheritance**
+EntityDefinition -> FileStoreProcessDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| FileStoreProcessDef() | Initializes a new instance. |
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| c_fileprocess_id | Column<string> | Identifier of the file processing operation. |
+| fsp_brwStandard | ViewDefinition | Browse view exposing file process identifiers. |
+
+## See Also
+- [FileStoreProcess](../FileStoreProcess/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/FileStoreStatus/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/FileStoreStatus/index.md
@@ -1,0 +1,16 @@
+# Class: MicroM.DataDictionary.FileStoreStatus
+## Overview
+Runtime entity representing the status of a stored file.
+
+**Inheritance**
+Entity<FileStoreStatusDef> -> FileStoreStatus
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| FileStoreStatus() | Initializes a new instance. |
+| FileStoreStatus(IEntityClient ec, IMicroMEncryption? encryptor = null) | Initializes with a database client and optional encryptor. |
+
+## See Also
+- [FileStoreStatusDef](../FileStoreStatusDef/index.md)
+- [FileStore](../FileStore/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/FileStoreStatusDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/FileStoreStatusDef/index.md
@@ -1,0 +1,25 @@
+# Class: MicroM.DataDictionary.FileStoreStatusDef
+## Overview
+Schema definition linking files to their status values.
+
+**Inheritance**
+EntityDefinition -> FileStoreStatusDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| FileStoreStatusDef() | Initializes a new instance. |
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| c_file_id | Column<string> | Identifier of the file. |
+| c_status_id | Column<string> | Identifier of the status set. |
+| c_statusvalue_id | Column<string> | Identifier of the status value. |
+| fsts_brwStandard | ViewDefinition | Browse view exposing file and status keys. |
+| FKFileStoreStatus | EntityForeignKey<FileStore, FileStoreStatus> | Link to the associated file. |
+| FKStatus | EntityForeignKey<StatusValues, FileStoreStatus> | Link to the status value. |
+
+## See Also
+- [FileStoreStatus](../FileStoreStatus/index.md)
+- [FileStore](../FileStore/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/Numbering/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/Numbering/index.md
@@ -1,0 +1,15 @@
+# Class: MicroM.DataDictionary.Numbering
+## Overview
+Runtime entity used to retrieve and update sequential numbers.
+
+**Inheritance**
+Entity<NumberingDef> -> Numbering
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| Numbering() | Initializes a new instance. |
+| Numbering(IEntityClient ec, IMicroMEncryption? encryptor = null) | Initializes with a database client and optional encryptor. |
+
+## See Also
+- [NumberingDef](../NumberingDef/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/NumberingDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/NumberingDef/index.md
@@ -1,0 +1,22 @@
+# Class: MicroM.DataDictionary.NumberingDef
+## Overview
+Schema definition for sequential number generation.
+
+**Inheritance**
+EntityDefinition -> NumberingDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| NumberingDef() | Initializes a new instance. |
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| c_object_id | Column<string> | Identifier of the object being numbered. |
+| bi_lastnumber | Column<long> | Last number generated for the object. |
+| num_brwStandard | ViewDefinition | Default browse view keyed by object ID. |
+| FKObjects | EntityForeignKey<Objects, Numbering> | Reference to the related object. |
+
+## See Also
+- [Numbering](../Numbering/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/index.md
@@ -11,12 +11,22 @@ Data dictionary entity definitions and related helpers.
 | [ApplicationOidcClients](ApplicationOidcClients/index.md) | Entity for OIDC client applications. |
 | [ApplicationOidcServerDef](ApplicationOidcServerDef/index.md) | Schema definition for OIDC server configuration. |
 | [ApplicationOidcServer](ApplicationOidcServer/index.md) | Entity for OIDC server configuration. |
+| [ApplicationsUrlsDef](ApplicationsUrlsDef/index.md) | Schema definition for application URLs. |
+| [ApplicationsUrls](ApplicationsUrls/index.md) | Entity for application URLs. |
 | [CategoriesDef](CategoriesDef/index.md) | Schema definition for categories. |
 | [Categories](Categories/index.md) | Entity for working with categories. |
 | [CategoriesValuesDef](CategoriesValuesDef/index.md) | Schema definition for category values. |
 | [CategoriesValues](CategoriesValues/index.md) | Entity for working with category values. |
+| [FileStoreDef](FileStoreDef/index.md) | Schema definition for stored files. |
+| [FileStore](FileStore/index.md) | Entity for stored files. |
+| [FileStoreProcessDef](FileStoreProcessDef/index.md) | Schema definition for file storage processes. |
+| [FileStoreProcess](FileStoreProcess/index.md) | Entity for file storage processes. |
+| [FileStoreStatusDef](FileStoreStatusDef/index.md) | Schema definition for file status records. |
+| [FileStoreStatus](FileStoreStatus/index.md) | Entity for file status records. |
 | [MicromMenusDef](MicromMenusDef/index.md) | Schema definition for MicroM menus. |
 | [MicromMenus](MicromMenus/index.md) | Entity for working with MicroM menus. |
+| [NumberingDef](NumberingDef/index.md) | Schema definition for sequential numbers. |
+| [Numbering](Numbering/index.md) | Entity for sequential number operations. |
 
 ## Enums
 | Enum | Description |
@@ -34,7 +44,7 @@ Data dictionary entity definitions and related helpers.
 | - | - |
 
 ## Remarks
-Additional types remain undocumented.
+Several additional entities remain undocumented.
 
 ## See Also
 -

--- a/MicroM/core/DataDictionary/Entities/FileStore/FileStore.cs
+++ b/MicroM/core/DataDictionary/Entities/FileStore/FileStore.cs
@@ -6,35 +6,93 @@ using MicroM.Web.Services;
 
 namespace MicroM.DataDictionary
 {
-
+    /// <summary>
+    /// Definition of the <c>FileStore</c> entity used to persist uploaded files and
+    /// their metadata within the system.
+    /// </summary>
     public class FileStoreDef : EntityDefinition
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileStoreDef"/> class.
+        /// </summary>
         public FileStoreDef() : base("fst", nameof(FileStore)) { SQLCreationOptions = SQLCreationOptionsMetadata.WithIUpdateAndIDrop; }
 
+        /// <summary>
+        /// Primary identifier of the stored file.
+        /// </summary>
         public readonly Column<string> c_file_id = Column<string>.PK(autonum: true);
+
+        /// <summary>
+        /// Identifier of the process that generated the file.
+        /// </summary>
         public readonly Column<string> c_fileprocess_id = Column<string>.FK();
+
+        /// <summary>
+        /// Name of the file as stored on disk.
+        /// </summary>
         public readonly Column<string> vc_filename = Column<string>.Text();
+
+        /// <summary>
+        /// Folder portion of the file path used for storage.
+        /// </summary>
         public readonly Column<string> vc_filefolder = Column<string>.Char(size: 6);
+
+        /// <summary>
+        /// Globally unique identifier associated with the file.
+        /// </summary>
         public readonly Column<string> vc_fileguid = Column<string>.Text(column_flags: ColumnFlags.Insert | ColumnFlags.Update | ColumnFlags.Delete | ColumnFlags.FK);
+
+        /// <summary>
+        /// Size of the file in bytes.
+        /// </summary>
         public readonly Column<long> bi_filesize = new();
+
+        /// <summary>
+        /// Status identifier tracking the upload progress of the file.
+        /// </summary>
         public readonly Column<string> c_fileuploadstatus_id = Column<string>.EmbedStatus(nameof(FileUpload));
 
+        /// <summary>
+        /// Standard browse view definition.
+        /// </summary>
         public readonly ViewDefinition fst_brwStandard = new(nameof(c_file_id));
+
+        /// <summary>
+        /// Browse view for retrieving files by process.
+        /// </summary>
         public readonly ViewDefinition fst_brwFiles = new(nameof(c_file_id), nameof(c_fileprocess_id));
 
+        /// <summary>
+        /// Procedure used to get a file by its GUID value.
+        /// </summary>
         public readonly ProcedureDefinition fst_getByGUID = new(new[] { nameof(vc_fileguid) });
 
+        /// <summary>
+        /// Foreign key to the associated <see cref="FileStoreProcess"/> record.
+        /// </summary>
         public readonly EntityForeignKey<FileStoreProcess, FileStore> FKFileStoreProcess = new();
-        public readonly EntityUniqueConstraint UCFileStore = new(keys: new[] { nameof(vc_fileguid) });
 
+        /// <summary>
+        /// Enforces uniqueness of <see cref="vc_fileguid"/> values.
+        /// </summary>
+        public readonly EntityUniqueConstraint UCFileStore = new(keys: new[] { nameof(vc_fileguid) });
     }
 
+    /// <summary>
+    /// Runtime entity for interacting with stored files.
+    /// </summary>
     public class FileStore : Entity<FileStoreDef>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileStore"/> class.
+        /// </summary>
         public FileStore() : base() { }
+
+        /// <summary>
+        /// Initializes a new instance with a database client and optional encryptor.
+        /// </summary>
+        /// <param name="ec">Database client used to access persistence layer.</param>
+        /// <param name="encryptor">Optional encryptor for sensitive data.</param>
         public FileStore(IEntityClient ec, IMicroMEncryption? encryptor = null) : base(ec, encryptor) { }
-
     }
-
-
 }

--- a/MicroM/core/DataDictionary/Entities/FileStore/FileStoreProcess.cs
+++ b/MicroM/core/DataDictionary/Entities/FileStore/FileStoreProcess.cs
@@ -5,24 +5,42 @@ using MicroM.Web.Services;
 
 namespace MicroM.DataDictionary
 {
-
+    /// <summary>
+    /// Definition of processes that handle file storage operations.
+    /// </summary>
     public class FileStoreProcessDef : EntityDefinition
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileStoreProcessDef"/> class.
+        /// </summary>
         public FileStoreProcessDef() : base("fsp", nameof(FileStoreProcess)) { SQLCreationOptions = SQLCreationOptionsMetadata.WithIUpdateAndIDrop; }
 
+        /// <summary>
+        /// Identifier of the file processing operation.
+        /// </summary>
         public readonly Column<string> c_fileprocess_id = Column<string>.PK(autonum: true);
 
+        /// <summary>
+        /// Browse view exposing file process identifiers.
+        /// </summary>
         public ViewDefinition fsp_brwStandard { get; private set; } = new(nameof(c_fileprocess_id));
-
     }
 
+    /// <summary>
+    /// Runtime entity representing a file storage process.
+    /// </summary>
     public class FileStoreProcess : Entity<FileStoreProcessDef>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileStoreProcess"/> class.
+        /// </summary>
         public FileStoreProcess() : base() { }
+
+        /// <summary>
+        /// Initializes a new instance with a database client and optional encryptor.
+        /// </summary>
+        /// <param name="ec">Database client used to interact with persistence.</param>
+        /// <param name="encryptor">Optional encryptor for sensitive columns.</param>
         public FileStoreProcess(IEntityClient ec, IMicroMEncryption? encryptor = null) : base(ec, encryptor) { }
-
-
     }
-
-
 }

--- a/MicroM/core/DataDictionary/Entities/FileStore/FileStoreStatus.cs
+++ b/MicroM/core/DataDictionary/Entities/FileStore/FileStoreStatus.cs
@@ -5,29 +5,62 @@ using MicroM.Web.Services;
 
 namespace MicroM.DataDictionary
 {
-
+    /// <summary>
+    /// Definition linking a file to its current status value.
+    /// </summary>
     public class FileStoreStatusDef : EntityDefinition
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileStoreStatusDef"/> class.
+        /// </summary>
         public FileStoreStatusDef() : base("fsts", nameof(FileStoreStatus)) { SQLCreationOptions = SQLCreationOptionsMetadata.WithIUpdateAndIDrop; }
 
+        /// <summary>
+        /// Identifier of the file.
+        /// </summary>
         public readonly Column<string> c_file_id = Column<string>.PK();
+
+        /// <summary>
+        /// Identifier of the status set.
+        /// </summary>
         public readonly Column<string> c_status_id = Column<string>.PK();
+
+        /// <summary>
+        /// Identifier of the specific status value.
+        /// </summary>
         public readonly Column<string> c_statusvalue_id = Column<string>.FK();
 
+        /// <summary>
+        /// Browse view exposing file and status keys.
+        /// </summary>
         public ViewDefinition fsts_brwStandard { get; private set; } = new(nameof(c_file_id), nameof(c_status_id));
 
+        /// <summary>
+        /// Foreign key to the associated <see cref="FileStore"/> record.
+        /// </summary>
         public readonly EntityForeignKey<FileStore, FileStoreStatus> FKFileStoreStatus = new();
-        public readonly EntityForeignKey<StatusValues, FileStoreStatus> FKStatus = new();
 
+        /// <summary>
+        /// Foreign key to the related <see cref="StatusValues"/> record.
+        /// </summary>
+        public readonly EntityForeignKey<StatusValues, FileStoreStatus> FKStatus = new();
     }
 
+    /// <summary>
+    /// Runtime entity representing the status of a stored file.
+    /// </summary>
     public class FileStoreStatus : Entity<FileStoreStatusDef>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileStoreStatus"/> class.
+        /// </summary>
         public FileStoreStatus() : base() { }
+
+        /// <summary>
+        /// Initializes a new instance with a database client and optional encryptor.
+        /// </summary>
+        /// <param name="ec">Database client used for persistence.</param>
+        /// <param name="encryptor">Optional encryptor for sensitive columns.</param>
         public FileStoreStatus(IEntityClient ec, IMicroMEncryption? encryptor = null) : base(ec, encryptor) { }
-
-
     }
-
-
 }

--- a/MicroM/core/DataDictionary/Entities/Numbering/Numbering.cs
+++ b/MicroM/core/DataDictionary/Entities/Numbering/Numbering.cs
@@ -18,23 +18,51 @@ using MicroM.Web.Services;
 
 namespace MicroM.DataDictionary;
 
+/// <summary>
+/// Definition for generating sequential numbers without relying on SQL Server sequences.
+/// </summary>
 public class NumberingDef : EntityDefinition
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NumberingDef"/> class.
+    /// </summary>
     public NumberingDef() : base("num", nameof(Numbering)) { }
 
+    /// <summary>
+    /// Identifier of the object being numbered.
+    /// </summary>
     public readonly Column<string> c_object_id = Column<string>.PK();
+
+    /// <summary>
+    /// Last number generated for the object.
+    /// </summary>
     public readonly Column<long> bi_lastnumber = new();
 
+    /// <summary>
+    /// Default browse view keyed by <see cref="c_object_id"/>.
+    /// </summary>
     public readonly ViewDefinition num_brwStandard = new(nameof(c_object_id));
 
+    /// <summary>
+    /// Foreign key reference to <see cref="Objects"/>.
+    /// </summary>
     public readonly EntityForeignKey<Objects, Numbering> FKObjects = new();
-
 }
 
+/// <summary>
+/// Runtime entity for retrieving and updating sequential numbers.
+/// </summary>
 public class Numbering : Entity<NumberingDef>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Numbering"/> class.
+    /// </summary>
     public Numbering() : base() { }
 
+    /// <summary>
+    /// Initializes a new instance with a database client and optional encryptor.
+    /// </summary>
+    /// <param name="ec">Database client used for persistence.</param>
+    /// <param name="encryptor">Optional encryptor for sensitive data.</param>
     public Numbering(IEntityClient ec, IMicroMEncryption? encryptor = null) : base(ec, encryptor) { }
-
 }

--- a/MicroM/core/DataDictionary/Entities/StatusDefinitions/EmailStatus.cs
+++ b/MicroM/core/DataDictionary/Entities/StatusDefinitions/EmailStatus.cs
@@ -3,14 +3,29 @@ using MicroM.DataDictionary.Configuration;
 
 namespace MicroM.DataDictionary.StatusDefs
 {
+    /// <summary>
+    /// Status values representing the lifecycle of an email in the queue.
+    /// </summary>
     public class EmailStatus : StatusDefinition
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmailStatus"/> class.
+        /// </summary>
         public EmailStatus() : base("EmailStatus") { }
 
+        /// <summary>Queued but not yet processed.</summary>
         public readonly StatusValuesDefinition QUEUED = new("Queued", true);
+
+        /// <summary>Currently being processed by the email sender.</summary>
         public readonly StatusValuesDefinition PROCESSING = new("Processing");
+
+        /// <summary>Email was sent successfully.</summary>
         public readonly StatusValuesDefinition SENT = new("Sent");
+
+        /// <summary>An error occurred while sending the email.</summary>
         public readonly StatusValuesDefinition ERROR = new("Error");
+
+        /// <summary>The email failed but is pending a retry attempt.</summary>
         public readonly StatusValuesDefinition RETRY = new("Pending retry");
     }
 }

--- a/MicroM/core/DataDictionary/Entities/StatusDefinitions/FileUpload.cs
+++ b/MicroM/core/DataDictionary/Entities/StatusDefinitions/FileUpload.cs
@@ -2,15 +2,29 @@
 
 namespace MicroM.DataDictionary.StatusDefs
 {
+    /// <summary>
+    /// Status values representing the lifecycle of a file upload.
+    /// </summary>
     public class FileUpload : StatusDefinition
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileUpload"/> class.
+        /// </summary>
         public FileUpload() : base("File Upload Status") { }
 
+        /// <summary>Upload is queued but not started.</summary>
         public readonly StatusValuesDefinition Pending = new("Pending", true);
-        public readonly StatusValuesDefinition Uploading = new("Uploading");
-        public readonly StatusValuesDefinition Uploaded = new("Uploaded");
-        public readonly StatusValuesDefinition Failed = new("Failed");
-        public readonly StatusValuesDefinition Cancelled = new("Cancelled");
 
+        /// <summary>Data is currently being transferred.</summary>
+        public readonly StatusValuesDefinition Uploading = new("Uploading");
+
+        /// <summary>Upload completed successfully.</summary>
+        public readonly StatusValuesDefinition Uploaded = new("Uploaded");
+
+        /// <summary>Upload failed due to an error.</summary>
+        public readonly StatusValuesDefinition Failed = new("Failed");
+
+        /// <summary>Upload was cancelled before completion.</summary>
+        public readonly StatusValuesDefinition Cancelled = new("Cancelled");
     }
 }

--- a/MicroM/core/DataDictionary/Entities/StatusDefinitions/ImportStatus.cs
+++ b/MicroM/core/DataDictionary/Entities/StatusDefinitions/ImportStatus.cs
@@ -2,14 +2,29 @@
 
 namespace MicroM.DataDictionary.StatusDefs
 {
+    /// <summary>
+    /// Status values describing the progress of a data import operation.
+    /// </summary>
     public class ImportStatus : StatusDefinition
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImportStatus"/> class.
+        /// </summary>
         public ImportStatus() : base("Import Status") { }
 
+        /// <summary>Import has been queued but not started.</summary>
         public readonly StatusValuesDefinition Pending = new("Pending", true);
+
+        /// <summary>The file format is invalid.</summary>
         public readonly StatusValuesDefinition FormatError = new("File format error");
+
+        /// <summary>Import is currently running.</summary>
         public readonly StatusValuesDefinition Importing = new("Importing");
+
+        /// <summary>Import completed successfully.</summary>
         public readonly StatusValuesDefinition Completed = new("Completed");
+
+        /// <summary>An unexpected error occurred during import.</summary>
         public readonly StatusValuesDefinition Error = new("Error");
     }
 }

--- a/MicroM/core/DataDictionary/Entities/StatusDefinitions/ProcessStatus.cs
+++ b/MicroM/core/DataDictionary/Entities/StatusDefinitions/ProcessStatus.cs
@@ -2,12 +2,20 @@
 
 namespace MicroM.DataDictionary.StatusDefs
 {
+    /// <summary>
+    /// Basic status values to track the execution of a process.
+    /// </summary>
     public class ProcessStatus : StatusDefinition
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProcessStatus"/> class.
+        /// </summary>
         public ProcessStatus() : base("Process Status") { }
 
+        /// <summary>Process has started.</summary>
         public readonly StatusValuesDefinition Started = new("Started", true);
-        public readonly StatusValuesDefinition Completed = new("Completed");
 
+        /// <summary>Process finished successfully.</summary>
+        public readonly StatusValuesDefinition Completed = new("Completed");
     }
 }


### PR DESCRIPTION
## Summary
- document file storage, numbering, and application URL classes in the data dictionary
- add docs for status definitions and update namespace indexes
- record documentation progress for DataDictionary namespaces

## Testing
- `dotnet build MicroM/core/MicroMCore.csproj`
- `dotnet test MicroM/LibraryTest/LibraryTest.csproj` *(fails: SQL Server connection string not valid)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e952cdac8324a51ab14290a32d12