### PR TITLE
docs: add template utility summaries

### DIFF
--- a/MicroM/core/Generators/Extensions/TemplateExtensions.cs
+++ b/MicroM/core/Generators/Extensions/TemplateExtensions.cs
@@ -2,8 +2,17 @@
 
 namespace MicroM.Generators.Extensions
 {
+    /// <summary>
+    /// Provides utility methods for processing string templates.
+    /// </summary>
     internal static class TemplateExtensions
     {
+        /// <summary>
+        /// Replaces template tokens with the corresponding values supplied in <paramref name="values"/>.
+        /// </summary>
+        /// <param name="template">The template string containing tokens enclosed in braces.</param>
+        /// <param name="values">The collection of token-value pairs used for replacement.</param>
+        /// <returns>The template string with all tokens replaced by their matching values.</returns>
         internal static string ReplaceTemplate(this string template, TemplateValuesBase values)
         {
             var sb = new StringBuilder(template);


### PR DESCRIPTION
## Summary
- document TemplateExtensions as a utility for string templates
- explain the token replacement logic in ReplaceTemplate

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: del not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f7cabb4883248fb3746cdeff3cd4