### PR TITLE
doc: add TemplateValuesBase token summary

### DIFF
--- a/MicroM/core/Generators/TemplateValuesBase.cs
+++ b/MicroM/core/Generators/TemplateValuesBase.cs
@@ -4,8 +4,14 @@ using System.Runtime.CompilerServices;
 
 namespace MicroM.Generators
 {
+    /// <summary>
+    /// Base class that manages placeholder tokens for template replacement.
+    /// </summary>
     internal abstract class TemplateValuesBase
     {
+        /// <summary>
+        /// Stores token–value pairs for template processing.
+        /// </summary>
         public readonly Dictionary<string, string> tokens = [];
 
         public TemplateValuesBase()
@@ -13,14 +19,19 @@ namespace MicroM.Generators
             FillTokens();
         }
 
-        // MMC: this aims to ease the use of the tokens dictionary
+        /// <summary>
+        /// Prepopulates the <see cref="tokens"/> dictionary with placeholders.
+        /// </summary>
+        /// <remarks>
+        /// Adds an empty string entry for each init-only string property defined on the instance, simplifying
+        /// subsequent token replacement.
+        /// </remarks>
         private void FillTokens()
         {
             object obj = this;
 
             IOrderedEnumerable<MemberInfo> instance_members = this.GetType().GetAndCacheInstanceMembers();
 
-            // MMC: this is to initialize the tokens dictionary with empty strings for all properties that are init only
             foreach (var prop in instance_members)
             {
                 bool isInitOnly = false;


### PR DESCRIPTION
## Summary
- document TemplateValuesBase and its token storage purpose
- describe FillTokens preload behavior for init-only properties

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: Could not resolve SDK "Microsoft.VisualStudio.JavaScript.Sdk"; NuGet.Config is not valid XML)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f7c9c2dc8324b1c222129003cd83