### PR TITLE
Add XML summaries for reusable regex helpers

### DIFF
--- a/MicroM/core/Generators/GeneratorsRegex.cs
+++ b/MicroM/core/Generators/GeneratorsRegex.cs
@@ -2,11 +2,22 @@
 
 namespace MicroM.Generators
 {
+    /// <summary>
+    /// Provides reusable regular expressions for generator utilities.
+    /// </summary>
     public partial class GeneratorsRegex
     {
+        /// <summary>
+        /// Matches two or more consecutive empty lines, optionally containing whitespace,
+        /// enabling removal of redundant blank lines.
+        /// </summary>
         [GeneratedRegex(@"[ \t]*\r?\n(\s*\r?\n)+", RegexOptions.Multiline)]
         public static partial Regex MultipleEmptyLines();
 
+        /// <summary>
+        /// Matches positions in a camel-cased identifier where an uppercase letter begins a
+        /// new word, allowing strings to be split into their component words.
+        /// </summary>
         [GeneratedRegex(@"(?<!^)(?=[A-Z])")]
         public static partial Regex SplitCamelCaseWords();
     }


### PR DESCRIPTION
## Summary
- document GeneratorsRegex class to describe its role as a collection of reusable patterns
- add summaries to regex methods for matching empty lines and splitting camel case

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: NuGet.Config is not valid XML)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f7c8f5a88324b523610b790c4162