### PR TITLE
Add XML docs to SQL generator helpers

### DIFF
--- a/MicroM/core/Generators/SQLGenerator/CategoriesAndStatusExtensions.cs
+++ b/MicroM/core/Generators/SQLGenerator/CategoriesAndStatusExtensions.cs
@@ -10,9 +10,20 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.SQLGenerator
 {
+    /// <summary>
+    /// Helper extensions for building SQL fragments that relate an entity to
+    /// its category or status tables.
+    /// </summary>
     internal static class CategoriesAndStatusExtensions
     {
         // MMC: this is too hard coded, it will be better to always define the entity for a _cat or _status table
+        /// <summary>
+        /// Generates the DDL to create the category/status table for an entity
+        /// together with the index used to reference it.
+        /// </summary>
+        /// <param name="entity">Entity whose supporting table will be created.</param>
+        /// <param name="is_status">True to create a status table, false for a category table.</param>
+        /// <returns>Two SQL scripts: the table DDL and the index creation.</returns>
         internal static List<string> CreateCategoryOrStatusTable(this EntityBase entity, bool is_status)
         {
             List<string> result = [];
@@ -71,6 +82,16 @@ namespace MicroM.Generators.SQLGenerator
             return result;
         }
 
+        /// <summary>
+        /// Builds the JOIN clause used to link an entity with its category or
+        /// status tables when querying.
+        /// </summary>
+        /// <typeparam name="T">Type of the entity.</typeparam>
+        /// <param name="entity">Entity whose joins are required.</param>
+        /// <param name="separator">Separator placed before each JOIN block.</param>
+        /// <param name="parent_alias">Alias of the parent table.</param>
+        /// <param name="alias">Starting alias for joined tables.</param>
+        /// <returns>Formatted SQL JOIN statements or an empty string.</returns>
         internal static string AsCategoriesAndStatusJoin<T>(this T entity, string separator = $"\n{TAB}{TAB}", string parent_alias = "a", string alias = "b") where T : EntityBase
         {
             if (entity.Def.RelatedCategories.Count == 0 && entity.Def.RelatedStatus.Count == 0) return "";

--- a/MicroM/core/Generators/SQLGenerator/CategoriesExtensions.cs
+++ b/MicroM/core/Generators/SQLGenerator/CategoriesExtensions.cs
@@ -9,6 +9,10 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.SQLGenerator
 {
+    /// <summary>
+    /// Extension methods that generate SQL snippets for handling entity
+    /// categories.
+    /// </summary>
     internal static class CategoriesExtensions
     {
         /// <summary>
@@ -24,6 +28,14 @@ namespace MicroM.Generators.SQLGenerator
             return entity.CreateCategoryOrStatusTable(false);
         }
 
+        /// <summary>
+        /// Builds the SQL used to parse JSON category arrays into temporary
+        /// tables for an entity.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="separator">Separator between generated statements.</param>
+        /// <returns>SQL fragment or empty string if no categories are defined.</returns>
         internal static string AsJSONCategories<T>(this T entity, string separator = $"\n{TAB}{TAB}{TAB}, ") where T : EntityBase
         {
             if (entity.Def.RelatedCategories.Count == 0) return "";
@@ -46,6 +58,13 @@ namespace MicroM.Generators.SQLGenerator
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Generates SQL to insert category records from JSON arrays for an entity.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="separator">Separator between values.</param>
+        /// <returns>SQL fragment or empty string when not applicable.</returns>
         internal static string AsInsertJSONCategories<T>(this T entity, string separator = $"\n{TAB}{TAB}{TAB}, ") where T : EntityBase
         {
             if (entity.Def.RelatedCategories.Count == 0) return "";
@@ -71,6 +90,15 @@ namespace MicroM.Generators.SQLGenerator
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Generates SQL to update category tables based on JSON arrays provided
+        /// for an entity.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="union_string">Union string used in WHERE clauses.</param>
+        /// <param name="separator">Separator between values.</param>
+        /// <returns>SQL fragment or empty string when not applicable.</returns>
         internal static string AsUpdateJSONCategories<T>(this T entity, string union_string = $"\n{TAB}{TAB}{TAB}and ", string separator = $"\n{TAB}{TAB}{TAB}, ") where T : EntityBase
         {
             if (entity.Def.RelatedCategories.Count == 0) return "";
@@ -96,6 +124,14 @@ namespace MicroM.Generators.SQLGenerator
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Creates the VALUES clause for inserting category rows related to an
+        /// entity.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="separator">Separator between values.</param>
+        /// <returns>SQL fragment or empty string when not applicable.</returns>
         internal static string AsCategoriesInsertValues<T>(this T entity, string separator = $"\n{TAB}{TAB}{TAB}, ") where T : EntityBase
         {
             if (entity.Def.RelatedCategories.Count == 0) return "";
@@ -145,6 +181,14 @@ namespace MicroM.Generators.SQLGenerator
         }
 
 
+        /// <summary>
+        /// Builds update statements for category tables using entity metadata.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="union_string">Union string used in WHERE clauses.</param>
+        /// <param name="separator">Separator between values.</param>
+        /// <returns>SQL fragment or empty string when not applicable.</returns>
         internal static string AsCategoriesUpdateTemplateValues<T>(this T entity, string union_string = $"\n{TAB}{TAB}{TAB}and ", string separator = $"\n{TAB}{TAB}{TAB}, ") where T : EntityBase
         {
             if (entity.Def.RelatedCategories.Count == 0) return "";
@@ -175,6 +219,14 @@ namespace MicroM.Generators.SQLGenerator
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Generates the DELETE clause for removing related category rows when an
+        /// entity record is dropped.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="separator">Separator used between conditions.</param>
+        /// <returns>SQL fragment or empty string when not applicable.</returns>
         internal static string AsCategoriesDelete<T>(this T entity, string separator = $"\n{TAB}{TAB}{TAB}and ") where T : EntityBase
         {
             if (entity.Def.RelatedCategories.Count == 0) return "";
@@ -192,6 +244,13 @@ namespace MicroM.Generators.SQLGenerator
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Builds SQL to return category values as JSON arrays for an entity.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="union_string">Union string used in WHERE clauses.</param>
+        /// <returns>SQL fragment or empty string when not applicable.</returns>
         internal static string AsJSONCategoriesGet<T>(this T entity, string union_string = $"\n{TAB}{TAB}and ") where T : EntityBase
         {
             if (entity.Def.RelatedCategories.Count == 0) return "";
@@ -217,6 +276,13 @@ namespace MicroM.Generators.SQLGenerator
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Produces the variable declarations required to hold JSON category
+        /// arrays when retrieving a record.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <returns>SQL declarations or empty string when not applicable.</returns>
         internal static string AsJSONCategoriesGetParmsDeclaration<T>(this T entity) where T : EntityBase
         {
             if (entity.Def.RelatedCategories.Count == 0) return "";

--- a/MicroM/core/Generators/SQLGenerator/DropExtensions.cs
+++ b/MicroM/core/Generators/SQLGenerator/DropExtensions.cs
@@ -6,8 +6,20 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.SQLGenerator
 {
+    /// <summary>
+    /// Extension helpers for generating DROP stored procedures.
+    /// </summary>
     internal static class DropExtensions
     {
+        /// <summary>
+        /// Creates scripts for the transactional <c>_idrop</c> procedure and a wrapper <c>_drop</c>
+        /// that invokes it.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="create_or_alter">True to generate <c>create or alter</c> header.</param>
+        /// <param name="force_fake">Generate code even if the entity is marked as fake.</param>
+        /// <returns>Scripts for the <c>_idrop</c> and calling <c>_drop</c> procedures.</returns>
         internal static List<string> AsCreateIDropProc<T>(this T entity, bool create_or_alter = false, bool force_fake = false) where T : EntityBase
         {
             List<string> scripts = [];
@@ -29,6 +41,15 @@ namespace MicroM.Generators.SQLGenerator
             return scripts;
         }
 
+        /// <summary>
+        /// Generates the basic <c>_drop</c> procedure that removes a record and
+        /// its related category/status rows.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="create_or_alter">True to generate <c>create or alter</c> header.</param>
+        /// <param name="force_fake">Generate code even if the entity is marked as fake.</param>
+        /// <returns>Script for the <c>_drop</c> stored procedure.</returns>
         internal static List<string> AsCreateNormalDropProc<T>(this T entity, bool create_or_alter = false, bool force_fake = false) where T : EntityBase
         {
             List<string> scripts = [];
@@ -50,6 +71,16 @@ namespace MicroM.Generators.SQLGenerator
             return scripts;
         }
 
+        /// <summary>
+        /// Returns the scripts required to create the drop stored procedure for
+        /// an entity, optionally including the transactional variant.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="create_or_alter">True to generate <c>create or alter</c> header.</param>
+        /// <param name="with_idrop">Include <c>_idrop</c> procedure if true.</param>
+        /// <param name="force_fake">Generate code even if entity is marked as fake.</param>
+        /// <returns>One or more SQL scripts implementing drop logic.</returns>
         public static List<string> AsCreateDropProc<T>(this T entity, bool create_or_alter = false, bool with_idrop = false, bool force_fake = false) where T : EntityBase
         {
             if (with_idrop)

--- a/MicroM/core/Generators/SQLGenerator/GetExtensions.cs
+++ b/MicroM/core/Generators/SQLGenerator/GetExtensions.cs
@@ -6,8 +6,20 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.SQLGenerator
 {
+    /// <summary>
+    /// Extensions for generating <c>_get</c> stored procedures that retrieve
+    /// complete entity records.
+    /// </summary>
     internal static class GetExtensions
     {
+        /// <summary>
+        /// Builds the SQL script for the <c>_get</c> procedure of an entity.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="create_or_alter">True to emit <c>create or alter</c> header.</param>
+        /// <param name="force">Generate script even if entity is marked fake.</param>
+        /// <returns>SQL script or empty string.</returns>
         public static string AsCreateGetProc<T>(this T entity, bool create_or_alter = false, bool force = false) where T : EntityBase
         {
             if (entity.Def.Fake && force == false) return "";

--- a/MicroM/core/Generators/SQLGenerator/JoinExtensions.cs
+++ b/MicroM/core/Generators/SQLGenerator/JoinExtensions.cs
@@ -7,6 +7,9 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.SQLGenerator
 {
+    /// <summary>
+    /// Extension methods for generating SQL JOIN clauses between entities.
+    /// </summary>
     internal static class JoinExtensions
     {
 
@@ -51,6 +54,18 @@ namespace MicroM.Generators.SQLGenerator
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Builds a JOIN clause between a parent and child entity based on the
+        /// defined foreign key.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="parent_entity">Parent entity.</param>
+        /// <param name="child_entity">Child entity.</param>
+        /// <param name="join_type">Type of join (e.g., join, left join).</param>
+        /// <param name="separator">Separator placed before the join.</param>
+        /// <param name="parent_alias">Alias of the parent table.</param>
+        /// <param name="child_alias">Alias of the child table.</param>
+        /// <returns>Formatted JOIN clause or empty string.</returns>
         internal static string AsSQLJoin<T>(this T parent_entity, T child_entity, string join_type = "join", string separator = $"\n{TAB}{TAB}{TAB}", string parent_alias = "a", string child_alias = "b") where T : EntityBase
         {
             StringBuilder sb = new();
@@ -63,6 +78,14 @@ namespace MicroM.Generators.SQLGenerator
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Generates join conditions by matching column names between two aliases.
+        /// </summary>
+        /// <param name="columns">Columns to compare.</param>
+        /// <param name="union_string">String used to join comparisons.</param>
+        /// <param name="parent_alias">Alias of the parent table.</param>
+        /// <param name="child_alias">Alias of the child table.</param>
+        /// <returns>Join condition string or empty string.</returns>
         internal static string AsSQLJoinColumnsByName(this CustomOrderedDictionary<ColumnBase>? columns, string union_string = " and ", string parent_alias = "a", string child_alias = "b")
         {
             if (columns == null) return "";

--- a/MicroM/core/Generators/SQLGenerator/LookupExtensions.cs
+++ b/MicroM/core/Generators/SQLGenerator/LookupExtensions.cs
@@ -6,8 +6,20 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.SQLGenerator
 {
+    /// <summary>
+    /// Extension methods for generating lookup stored procedures.
+    /// </summary>
     internal static class LookupExtensions
     {
+        /// <summary>
+        /// Builds the SQL script for the <c>_lookup</c> stored procedure used to
+        /// return a description column for a record.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="create_or_alter">True to emit <c>create or alter</c>.</param>
+        /// <param name="force">Generate script even if entity is marked fake.</param>
+        /// <returns>SQL script for the lookup procedure or an empty string.</returns>
         public static string AsCreateLookupProc<T>(this T entity, bool create_or_alter = false, bool force = false) where T : EntityBase
         {
             if (entity.Def.Fake && force == false) return "";

--- a/MicroM/core/Generators/SQLGenerator/SecurityExtensions.cs
+++ b/MicroM/core/Generators/SQLGenerator/SecurityExtensions.cs
@@ -4,8 +4,19 @@ using System.Text;
 
 namespace MicroM.Generators.SQLGenerator
 {
+    /// <summary>
+    /// Extensions for generating security scripts related to SQL objects.
+    /// </summary>
     internal static class SecurityExtensions
     {
+        /// <summary>
+        /// Builds a script granting execute permissions on all procedures and
+        /// views generated for an entity.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="login_or_group_name">Login or role that receives permissions.</param>
+        /// <returns>SQL GRANT script.</returns>
         public static string AsGrantExecutionToAllProcs<T>(this T entity, string login_or_group_name) where T : EntityBase
         {
             StringBuilder sb = new();

--- a/MicroM/core/Generators/SQLGenerator/StatusExtensions.cs
+++ b/MicroM/core/Generators/SQLGenerator/StatusExtensions.cs
@@ -9,6 +9,9 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.SQLGenerator
 {
+    /// <summary>
+    /// Extension methods for generating SQL related to entity status values.
+    /// </summary>
     internal static class StatusExtensions
     {
         /// <summary>
@@ -16,14 +19,22 @@ namespace MicroM.Generators.SQLGenerator
         /// The status table name for the specified <seealso cref="Entity{TDefinition}"/> will be <![CDATA[<entity table name>_status]]>.
         /// The columns will contain the <see cref="Entity{TDefinition}"/> primary keys + <seealso cref="Status"/> primary keys + <see cref="DefaultColumns"/>
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="entity"></param>
-        /// <returns></returns>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <returns>DDL script for table and index.</returns>
         internal static List<string> CreateStatusTable<T>(this T entity) where T : EntityBase
         {
             return entity.CreateCategoryOrStatusTable(true);
         }
 
+        /// <summary>
+        /// Builds the VALUES clause to insert initial status rows for an entity.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="separator">Separator between values.</param>
+        /// <param name="status_alias">Alias used for status table references.</param>
+        /// <returns>SQL fragment or empty string when status is not related.</returns>
         internal static string AsStatusInsertValues<T>(this T entity, string separator = $"\n{TAB}{TAB}{TAB}{TAB}, ", string status_alias = "a") where T : EntityBase
         {
             if (entity.Def.RelatedStatus.Count == 0) return "";
@@ -44,6 +55,13 @@ namespace MicroM.Generators.SQLGenerator
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Generates a DELETE statement to remove status rows for an entity.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="separator">Separator used in the WHERE clause.</param>
+        /// <returns>SQL fragment or empty string when not applicable.</returns>
         internal static string AsStatusDelete<T>(this T entity, string separator = $"\n{TAB}{TAB}{TAB}and ") where T : EntityBase
         {
             if (entity.Def.RelatedStatus.Count == 0) return "";
@@ -61,6 +79,15 @@ namespace MicroM.Generators.SQLGenerator
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Creates UPDATE statements for status tables using values supplied via
+        /// stored procedure parameters.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="union_string">Separator used in WHERE clauses.</param>
+        /// <param name="separator">Separator between values.</param>
+        /// <returns>SQL fragment or empty string when not applicable.</returns>
         internal static string AsStatusUpdateTemplateValues<T>(this T entity, string union_string = $"\n{TAB}{TAB}{TAB}and ", string separator = $"\n{TAB}{TAB}{TAB}, ") where T : EntityBase
         {
             if (entity.Def.RelatedStatus.Count == 0) return "";

--- a/MicroM/core/Generators/SQLGenerator/TableExtensions.cs
+++ b/MicroM/core/Generators/SQLGenerator/TableExtensions.cs
@@ -259,6 +259,12 @@ namespace MicroM.Generators.SQLGenerator
             return result;
         }
 
+        /// <summary>
+        /// Builds a script that drops all indexes defined on the entity table.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity whose indexes will be dropped.</param>
+        /// <returns>DDL script or <c>null</c> if the entity is fake.</returns>
         public static string? AsDropIndexes<T>(this T entity) where T : EntityBase
         {
             if (entity.Def.Fake) return null;
@@ -276,6 +282,13 @@ namespace MicroM.Generators.SQLGenerator
             return sb_indexes.ToString();
         }
 
+        /// <summary>
+        /// Generates a script to create indexes defined on the entity table if
+        /// they do not already exist.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity containing index definitions.</param>
+        /// <returns>DDL script or <c>null</c> if the entity is fake.</returns>
         public static string? AsCreateIndexes<T>(this T entity) where T : EntityBase
         {
             if (entity.Def.Fake) return null;
@@ -295,6 +308,12 @@ namespace MicroM.Generators.SQLGenerator
             return sb_indexes.ToString();
         }
 
+        /// <summary>
+        /// Creates a script to remove unique constraints from the entity table.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity providing constraint metadata.</param>
+        /// <returns>DDL script or <c>null</c> if the entity is fake.</returns>
         public static string? AsDropUniqueConstraints<T>(this T entity) where T : EntityBase
         {
             if (entity.Def.Fake) return null;
@@ -312,6 +331,13 @@ namespace MicroM.Generators.SQLGenerator
             return sb_uniqueConstraints.ToString();
         }
 
+        /// <summary>
+        /// Builds a script to add unique constraints that are defined in the
+        /// entity metadata but not yet present in the database.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity providing constraint definitions.</param>
+        /// <returns>DDL script or <c>null</c> if the entity is fake.</returns>
         public static string? AsAlterUniqueConstraints<T>(this T entity) where T : EntityBase
         {
             if (entity.Def.Fake) return null;
@@ -331,6 +357,13 @@ namespace MicroM.Generators.SQLGenerator
             return sb_uniqueConstraints.ToString();
         }
 
+        /// <summary>
+        /// Creates a script that drops the primary key constraint for the entity
+        /// table if it exists.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <returns>DDL script or <c>null</c> if the entity is fake.</returns>
         public static string? AsDropPrimaryKey<T>(this T entity) where T : EntityBase
         {
             if (entity.Def.Fake) return null;
@@ -338,6 +371,13 @@ namespace MicroM.Generators.SQLGenerator
             return $"if object_id('{entity.Def.TableName}') is not null ALTER TABLE [{entity.Def.TableName}] DROP CONSTRAINT IF EXISTS PK{entity.Def.Mneo}\n";
         }
 
+        /// <summary>
+        /// Builds a script that creates the primary key constraint if it is
+        /// missing from the entity table.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity metadata.</param>
+        /// <returns>DDL script or <c>null</c> if the entity is fake.</returns>
         public static string? AsAlterPrimaryKey<T>(this T entity) where T : EntityBase
         {
             if (entity.Def.Fake) return null;
@@ -353,6 +393,13 @@ namespace MicroM.Generators.SQLGenerator
             return result;
         }
 
+        /// <summary>
+        /// Produces a script that drops all foreign key constraints for the
+        /// entity table.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <returns>DDL script or <c>null</c> if the entity is fake.</returns>
         public static string? AsDropForeignKeys<T>(this T entity) where T : EntityBase
         {
             if (entity.Def.Fake) return null;
@@ -371,6 +418,13 @@ namespace MicroM.Generators.SQLGenerator
             return sb_foreign_keys.Append(sb_foreign_keys).ToString();
         }
 
+        /// <summary>
+        /// Generates index creation scripts for each foreign key defined on the
+        /// entity.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity whose foreign keys require indexes.</param>
+        /// <returns>DDL script or <c>null</c> if the entity is fake.</returns>
         public static string? AsCreateForeignKeysIndexes<T>(this T entity) where T : EntityBase
         {
             if (entity.Def.Fake) return null;
@@ -459,6 +513,14 @@ namespace MicroM.Generators.SQLGenerator
             return sb_indexes.ToString();
         }
 
+        /// <summary>
+        /// Builds scripts to create foreign key constraints that are not present
+        /// in the database. Existing constraints can optionally be dropped first.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="with_drop">True to drop existing constraints before creating new ones.</param>
+        /// <returns>DDL script or <c>null</c> if the entity is fake.</returns>
         public static string? AsAlterForeignKeys<T>(this T entity, bool with_drop = false) where T : EntityBase
         {
             if (entity.Def.Fake) return null;
@@ -554,6 +616,14 @@ namespace MicroM.Generators.SQLGenerator
             return sb_foreign_keys.ToString();
         }
 
+        /// <summary>
+        /// Creates a script granting execute permissions on all procedures and
+        /// views generated for the entity.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="login_or_group_name">Login or database role to receive permissions.</param>
+        /// <returns>SQL grant script.</returns>
         public static string AsGrantExecutionToEntityProcsScript<T>(this T entity, string login_or_group_name) where T : EntityBase
         {
 

--- a/MicroM/core/Generators/SQLGenerator/TemplateValues.cs
+++ b/MicroM/core/Generators/SQLGenerator/TemplateValues.cs
@@ -1,45 +1,87 @@
 ﻿namespace MicroM.Generators.SQLGenerator
 {
+    /// <summary>
+    /// Dictionary of tokens used to replace placeholders within SQL templates.
+    /// </summary>
     internal class TemplateValues : TemplateValuesBase
     {
+        /// <summary>Placeholder for the entity MNEO name.</summary>
         public string MNEO { get => tokens[nameof(MNEO)]; init => tokens[nameof(MNEO)] = value; }
+        /// <summary>Declaration list for procedure parameters.</summary>
         public string PARMS_DECLARATION { get => tokens[nameof(PARMS_DECLARATION)]; init => tokens[nameof(PARMS_DECLARATION)] = value; }
+        /// <summary>Declaration for autonumber variables.</summary>
         public string AUTONUM_DECLARE { get => tokens[nameof(AUTONUM_DECLARE)]; init => tokens[nameof(AUTONUM_DECLARE)] = value; }
+        /// <summary>Fully qualified table name.</summary>
         public string TABLE_NAME { get => tokens[nameof(TABLE_NAME)]; init => tokens[nameof(TABLE_NAME)] = value; }
+        /// <summary>WHERE clause used for filtering.</summary>
         public string WHERE_CLAUSE { get => tokens[nameof(WHERE_CLAUSE)]; init => tokens[nameof(WHERE_CLAUSE)] = value; }
+        /// <summary>VALUES list used for INSERT statements.</summary>
         public string INSERT_VALUES { get => tokens[nameof(INSERT_VALUES)]; init => tokens[nameof(INSERT_VALUES)] = value; }
+        /// <summary>SET clause used in UPDATE statements.</summary>
         public string UPDATE_VALUES { get => tokens[nameof(UPDATE_VALUES)]; init => tokens[nameof(UPDATE_VALUES)] = value; }
+        /// <summary>Column list used for SELECT statements.</summary>
         public string GET_VALUES { get => tokens[nameof(GET_VALUES)]; init => tokens[nameof(GET_VALUES)] = value; }
+        /// <summary>Description column used by lookup procedures.</summary>
         public string DESC_COLUMN { get => tokens[nameof(DESC_COLUMN)]; init => tokens[nameof(DESC_COLUMN)] = value; }
+        /// <summary>Columns returned by view procedures.</summary>
         public string VIEW_COLUMNS { get => tokens[nameof(VIEW_COLUMNS)]; init => tokens[nameof(VIEW_COLUMNS)] = value; }
+        /// <summary><c>create</c> or <c>create or alter</c> keyword.</summary>
         public string CREATE { get => tokens[nameof(CREATE)]; private set => tokens[nameof(CREATE)] = value; }
+        /// <summary>Script fragment used to generate autonumbers.</summary>
         public string AUTONUM { get => tokens[nameof(AUTONUM)]; init => tokens[nameof(AUTONUM)] = value; }
+        /// <summary>Name of the categories table for the entity.</summary>
         public string CATEGORIES_TABLE { get => tokens[nameof(CATEGORIES_TABLE)]; init => tokens[nameof(CATEGORIES_TABLE)] = value; }
+        /// <summary>Name of the status table for the entity.</summary>
         public string STATUS_TABLE { get => tokens[nameof(STATUS_TABLE)]; init => tokens[nameof(STATUS_TABLE)] = value; }
+        /// <summary>SQL used to update category rows.</summary>
         public string CATEGORIES_UPDATE { get => tokens[nameof(CATEGORIES_UPDATE)]; init => tokens[nameof(CATEGORIES_UPDATE)] = value; }
+        /// <summary>SQL used to insert category rows.</summary>
         public string CATEGORIES_INSERT { get => tokens[nameof(CATEGORIES_INSERT)]; init => tokens[nameof(CATEGORIES_INSERT)] = value; }
+        /// <summary>JOIN clause for category tables.</summary>
         public string CATEGORIES_JOIN { get => tokens[nameof(CATEGORIES_JOIN)]; init => tokens[nameof(CATEGORIES_JOIN)] = value; }
+        /// <summary>SQL used to delete category rows.</summary>
         public string CATEGORIES_DELETE { get => tokens[nameof(CATEGORIES_DELETE)]; init => tokens[nameof(CATEGORIES_DELETE)] = value; }
+        /// <summary>SQL used to insert status rows.</summary>
         public string STATUS_INSERT { get => tokens[nameof(STATUS_INSERT)]; init => tokens[nameof(STATUS_INSERT)] = value; }
+        /// <summary>SQL used to delete status rows.</summary>
         public string STATUS_DELETE { get => tokens[nameof(STATUS_DELETE)]; init => tokens[nameof(STATUS_DELETE)] = value; }
+        /// <summary>SQL used to update status rows.</summary>
         public string STATUS_UPDATE { get => tokens[nameof(STATUS_UPDATE)]; init => tokens[nameof(STATUS_UPDATE)] = value; }
+        /// <summary>Parameter name representing a status value.</summary>
         public string STATUS_PARM { get => tokens[nameof(STATUS_PARM)]; init => tokens[nameof(STATUS_PARM)] = value; }
+        /// <summary>Return statement for autonumber values.</summary>
         public string AUTONUM_RETURN { get => tokens[nameof(AUTONUM_RETURN)]; init => tokens[nameof(AUTONUM_RETURN)] = value; }
+        /// <summary>Comma separated parameter list.</summary>
         public string PARMS { get => tokens[nameof(PARMS)]; init => tokens[nameof(PARMS)] = value; }
+        /// <summary>Validation block for input parameters.</summary>
         public string PARMS_VALIDATION { get => tokens[nameof(PARMS_VALIDATION)]; init => tokens[nameof(PARMS_VALIDATION)] = value; }
+        /// <summary>UPDATE clause for the main table.</summary>
         public string UPDATE_CLAUSE { get => tokens[nameof(UPDATE_CLAUSE)]; init => tokens[nameof(UPDATE_CLAUSE)] = value; }
+        /// <summary>Optimistic locking control segment.</summary>
         public string UPDATE_LU_CONTROL { get => tokens[nameof(UPDATE_LU_CONTROL)]; init => tokens[nameof(UPDATE_LU_CONTROL)] = value; }
+        /// <summary>Parameter name for category identifiers.</summary>
         public string CATEGORY_PARM { get => tokens[nameof(CATEGORY_PARM)]; init => tokens[nameof(CATEGORY_PARM)] = value; }
+        /// <summary>Conditional delete clause when category parameter is null.</summary>
         public string CATEGORY_DELETE_NULL { get => tokens[nameof(CATEGORY_DELETE_NULL)]; init => tokens[nameof(CATEGORY_DELETE_NULL)] = value; }
+        /// <summary>Fragment that prepares JSON category arrays.</summary>
         public string JSON_CATEGORIES { get => tokens[nameof(JSON_CATEGORIES)]; init => tokens[nameof(JSON_CATEGORIES)] = value; }
+        /// <summary>Identifier of a category.</summary>
         public string CATEGORY { get => tokens[nameof(CATEGORY)]; init => tokens[nameof(CATEGORY)] = value; }
+        /// <summary>Temporary table name for parsed categories.</summary>
         public string CATEGORY_TEMP_TABLE { get => tokens[nameof(CATEGORY_TEMP_TABLE)]; init => tokens[nameof(CATEGORY_TEMP_TABLE)] = value; }
+        /// <summary>SQL used to insert parsed JSON categories.</summary>
         public string JSON_CATEGORIES_INSERT { get => tokens[nameof(JSON_CATEGORIES_INSERT)]; init => tokens[nameof(JSON_CATEGORIES_INSERT)] = value; }
+        /// <summary>SQL used to update categories from JSON arrays.</summary>
         public string JSON_CATEGORIES_UPDATE { get => tokens[nameof(JSON_CATEGORIES_UPDATE)]; init => tokens[nameof(JSON_CATEGORIES_UPDATE)] = value; }
+        /// <summary>Declarations for variables used to hold JSON arrays.</summary>
         public string JSON_PARMS_DECLARATION { get => tokens[nameof(JSON_PARMS_DECLARATION)]; init => tokens[nameof(JSON_PARMS_DECLARATION)] = value; }
+        /// <summary>SQL used to fetch category values as JSON.</summary>
         public string JSON_CATEGORIES_GET { get => tokens[nameof(JSON_CATEGORIES_GET)]; init => tokens[nameof(JSON_CATEGORIES_GET)] = value; }
+        /// <summary>Statements that convert empty strings to NULL.</summary>
         public string NULLIF_CHECKS { get => tokens[nameof(NULLIF_CHECKS)]; init => tokens[nameof(NULLIF_CHECKS)] = value; }
+        /// <summary>LIKE clause used in view filters.</summary>
         public string LIKE_CLAUSE { get => tokens[nameof(LIKE_CLAUSE)]; init => tokens[nameof(LIKE_CLAUSE)] = value; }
+        /// <summary>Template fragment for the LIKE filter.</summary>
         public string LIKE_TEMPLATE { get => tokens[nameof(LIKE_TEMPLATE)]; init => tokens[nameof(LIKE_TEMPLATE)] = value; }
 
         public TemplateValues(bool create_or_alter = false) : base()

--- a/MicroM/core/Generators/SQLGenerator/Templates.cs
+++ b/MicroM/core/Generators/SQLGenerator/Templates.cs
@@ -1,7 +1,12 @@
 ﻿namespace MicroM.Generators.SQLGenerator
 {
+    /// <summary>
+    /// Collection of SQL template strings used to generate stored procedures
+    /// and related scripts.
+    /// </summary>
     internal class Templates
     {
+        /// <summary>Template for a LIKE filter using the sys_tfLike table.</summary>
         internal const string LIKE_TEMPLATE =
 @"
         not exists (
@@ -13,6 +18,7 @@
             )
         )
 ";
+        /// <summary>Template for the standard browse view stored procedure.</summary>
         internal const string VIEW_TEMPLATE =
 @"
 {CREATE} proc {MNEO}_brwStandard
@@ -24,6 +30,7 @@ from    {TABLE_NAME}{CATEGORIES_JOIN}
 where   {WHERE_CLAUSE}
 ";
 
+        /// <summary>Template for the non-transactional drop procedure.</summary>
         internal const string DROP_TEMPLATE =
 @"
 {CREATE} proc {MNEO}_drop
@@ -55,6 +62,7 @@ begin catch
 end catch
 ";
 
+        /// <summary>Template for the transactional <c>_idrop</c> procedure.</summary>
         internal const string IDROP_TEMPLATE =
 @"
 {CREATE} proc {MNEO}_idrop
@@ -82,6 +90,7 @@ begin catch
 end catch
 ";
 
+        /// <summary>Template for a wrapper drop procedure that calls <c>_idrop</c>.</summary>
         internal const string DROP_CALLS_IDROP_TEMPLATE =
 @"
 {CREATE} proc {MNEO}_drop
@@ -121,6 +130,7 @@ begin catch
 end catch
 ";
 
+        /// <summary>Template for the <c>_lookup</c> stored procedure.</summary>
         internal const string LOOKUP_TEMPLATE =
 @"
 {CREATE} proc {MNEO}_lookup
@@ -132,6 +142,7 @@ from    {TABLE_NAME}
 where   {WHERE_CLAUSE}
 ";
 
+        /// <summary>Template for fetching category values as a JSON array.</summary>
         internal const string JSON_CATEGORY_GET_TEMPLATE =
 @"
 select  {CATEGORY_PARM} = '[' + STRING_AGG('""'+replace(RTRIM(c_categoryvalue_id), '""','\""')+'""', ',') + ']'
@@ -140,6 +151,7 @@ where   {WHERE_CLAUSE}
 ";
 
 
+        /// <summary>Template for the <c>_get</c> stored procedure.</summary>
         internal const string GET_TEMPLATE =
 @"
 {CREATE} proc {MNEO}_get
@@ -153,6 +165,7 @@ from    {TABLE_NAME}{CATEGORIES_JOIN}
 where   {WHERE_CLAUSE}
 ";
 
+        /// <summary>Optimistic locking check used in update procedures.</summary>
         internal const string UPDATE_LU_CONTROL_TEMPLATE =
 @"
     if @cu<>@lu or @lu is null 
@@ -164,6 +177,7 @@ where   {WHERE_CLAUSE}
 
 ";
 
+        /// <summary>Lock check for transactional <c>_iupdate</c> procedures.</summary>
         internal const string IUPDATE_LU_CONTROL_TEMPLATE =
 @"
     if @cu<>@lu or @lu is null 
@@ -174,6 +188,7 @@ where   {WHERE_CLAUSE}
 
 ";
 
+        /// <summary>Template for the main UPDATE statement in procedures.</summary>
         internal const string UPDATE_CLAUSE_TEMPLATE =
 @"
     update  {TABLE_NAME}
@@ -184,6 +199,7 @@ where   {WHERE_CLAUSE}
     where   {WHERE_CLAUSE}
 ";
 
+        /// <summary>Template to parse JSON category arrays into a temp table.</summary>
         internal const string JSON_CATEGORIES_PARSE_TEMPLATE =
         @"
     create table {CATEGORY_TEMP_TABLE} (jsoncategory_id char(20), category_desc varchar(max))
@@ -219,6 +235,7 @@ where   {WHERE_CLAUSE}
 ";
 
 
+        /// <summary>Template for inserting parsed JSON categories.</summary>
         internal const string INSERT_JSON_CAT_TEMPLATE =
         @"
         if ({CATEGORY_PARM} is not null)
@@ -237,6 +254,7 @@ where   {WHERE_CLAUSE}
         end
 ";
 
+        /// <summary>Template for updating category table based on JSON input.</summary>
         internal const string UPDATE_JSON_CAT_TEMPLATE =
         @"
     delete  {CATEGORIES_TABLE}
@@ -261,6 +279,7 @@ where   {WHERE_CLAUSE}
 ";
 
 
+        /// <summary>Template for the standard <c>_update</c> procedure.</summary>
         internal const string UPDATE_TEMPLATE =
 @"
 {CREATE} proc {MNEO}_update
@@ -322,6 +341,7 @@ begin catch
 end catch
 ";
 
+        /// <summary>Template for the transactional <c>_iupdate</c> procedure.</summary>
         internal const string IUPDATE_TEMPLATE =
 @"
 {CREATE} proc {MNEO}_iupdate
@@ -375,6 +395,7 @@ begin catch
 end catch
 ";
 
+        /// <summary>Template for wrapper <c>_update</c> calling <c>_iupdate</c>.</summary>
         internal const string UPDATE_CALLS_IUPDATE_TEMPLATE =
 @"
 {CREATE} proc {MNEO}_update
@@ -418,6 +439,7 @@ begin catch
 end catch
 ";
 
+        /// <summary>Template for inserting a category when the parameter may be null.</summary>
         internal const string INSERT_CATEGORY_TEMPLATE_NULL =
 @"
         if ({CATEGORY_PARM} is not null)
@@ -438,6 +460,7 @@ end catch
         end
 ";
 
+        /// <summary>Template for inserting a category value.</summary>
         internal const string INSERT_CATEGORY_TEMPLATE =
 @"
         insert  {CATEGORIES_TABLE}
@@ -453,6 +476,7 @@ end catch
             )
 ";
 
+        /// <summary>Template for deleting category rows when parameter is null.</summary>
         internal const string DELETE_CATEGORY_NULL_TEMPLATE =
 @"
     if ({CATEGORY_PARM} is null)
@@ -465,6 +489,7 @@ end catch
 
 ";
 
+        /// <summary>Template for updating an existing category value.</summary>
         internal const string UPDATE_CATEGORY_TEMPLATE =
 @"
     {CATEGORY_DELETE_NULL}
@@ -504,12 +529,14 @@ end catch
     end
 ";
 
+        /// <summary>Template for deleting category rows.</summary>
         internal const string DELETE_CATEGORY_TEMPLATE =
 @"
     delete  {CATEGORIES_TABLE}
     where   {WHERE_CLAUSE}
 ";
 
+        /// <summary>Template for inserting default status rows.</summary>
         internal const string INSERT_STATUS_TEMPLATE =
 @"
         insert  {STATUS_TABLE}
@@ -529,12 +556,14 @@ end catch
                 a.bt_initial_value = 1
 ";
 
+        /// <summary>Template for deleting status rows.</summary>
         internal const string DELETE_STATUS_TEMPLATE =
 @"
     delete  {STATUS_TABLE}
     where   {WHERE_CLAUSE}
 ";
 
+        /// <summary>Template for updating a status value.</summary>
         internal const string UPDATE_STATUS_TEMPLATE =
 @"
     update  {STATUS_TABLE}

--- a/MicroM/core/Generators/SQLGenerator/UpdateExtensions.cs
+++ b/MicroM/core/Generators/SQLGenerator/UpdateExtensions.cs
@@ -7,6 +7,10 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.SQLGenerator
 {
+    /// <summary>
+    /// Extension methods for generating SQL update procedures and related
+    /// helper scripts for entities.
+    /// </summary>
     internal static class UpdateExtensions
     {
         private static string GetAutonum(this EntityBase entity)
@@ -42,6 +46,14 @@ namespace MicroM.Generators.SQLGenerator
         }
 
 
+        /// <summary>
+        /// Builds the standard <c>_update</c> stored procedure script for an entity.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="create_or_alter">True to emit a <c>create or alter</c> header.</param>
+        /// <param name="force">Generate script even if the entity is marked fake.</param>
+        /// <returns>SQL script or empty string when not applicable.</returns>
         internal static string GetUpdateProc<T>(this T entity, bool create_or_alter = false, bool force = false) where T : EntityBase
         {
             if (entity.Def.Fake && force == false) return "";
@@ -96,6 +108,15 @@ namespace MicroM.Generators.SQLGenerator
             return Templates.UPDATE_TEMPLATE.ReplaceTemplate(parms).RemoveEmptyLines();
         }
 
+        /// <summary>
+        /// Generates the transactional <c>_iupdate</c> stored procedure script for
+        /// an entity.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="create_or_alter">True to emit a <c>create or alter</c> header.</param>
+        /// <param name="force">Generate script even if the entity is marked fake.</param>
+        /// <returns>SQL script or empty string when not applicable.</returns>
         internal static string GetIUpdateProc<T>(this T entity, bool create_or_alter = false, bool force = false) where T : EntityBase
         {
             if (entity.Def.Fake && force == false) return "";
@@ -151,6 +172,15 @@ namespace MicroM.Generators.SQLGenerator
         }
 
 
+        /// <summary>
+        /// Creates the wrapper <c>_update</c> procedure that calls the
+        /// transactional <c>_iupdate</c> procedure.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="create_or_alter">True to emit a <c>create or alter</c> header.</param>
+        /// <param name="force">Generate script even if the entity is marked fake.</param>
+        /// <returns>SQL script or empty string when not applicable.</returns>
         internal static string GetUpdateForIUpdateProc<T>(this T entity, bool create_or_alter = false, bool force = false) where T : EntityBase
         {
             if (entity.Def.Fake && force == false) return "";
@@ -169,14 +199,14 @@ namespace MicroM.Generators.SQLGenerator
         }
 
         /// <summary>
-        /// Returns a SQL script to create the default _update stored procedure for the specified <see cref="Entity{TDefinition}"/>.
+        /// Creates the scripts for the entity's update stored procedures.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="entity"></param>
-        /// <param name="create_or_alter"></param>
-        /// <param name="with_iupdate"></param>
-        /// <param name="force"></param>
-        /// <returns></returns>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="create_or_alter">True to emit <c>create or alter</c> headers.</param>
+        /// <param name="with_iupdate">Include transactional <c>_iupdate</c> variant if true.</param>
+        /// <param name="force">Generate scripts even if the entity is marked fake.</param>
+        /// <returns>List of SQL scripts implementing update logic.</returns>
         public static List<string> AsCreateUpdateProc<T>(this T entity, bool create_or_alter = false, bool with_iupdate = false, bool force = false) where T : EntityBase
         {
             List<string> scripts = [];

--- a/MicroM/core/Generators/SQLGenerator/ViewExtensions.cs
+++ b/MicroM/core/Generators/SQLGenerator/ViewExtensions.cs
@@ -6,8 +6,20 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.SQLGenerator
 {
+    /// <summary>
+    /// Extensions for generating SQL scripts for entity browse views.
+    /// </summary>
     internal static class ViewExtensions
     {
+        /// <summary>
+        /// Builds the SQL script for the standard browse view stored procedure
+        /// (<c>_brwStandard</c>) of an entity.
+        /// </summary>
+        /// <typeparam name="T">Entity type.</typeparam>
+        /// <param name="entity">Entity definition.</param>
+        /// <param name="create_or_alter">Emit <c>create or alter</c> if true.</param>
+        /// <param name="force">Generate script even when entity is marked fake.</param>
+        /// <returns>SQL script or explanatory comment if view is missing.</returns>
         public static string AsCreateViewProc<T>(this T entity, bool create_or_alter = false, bool force = false) where T : EntityBase
         {
             if (entity.Def.Fake && force == false) return "";


### PR DESCRIPTION
## Summary
- document SQL column and join helpers with summaries and parameter notes
- add XML docs for token properties used in SQL templates
- explain SQL template string constants

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f9778e6083248ead95cf974df958