### PR TITLE
docs: add XML comments for React generator

### DIFF
--- a/MicroM/core/Generators/ReactGenerator/CategoriesExtensions.cs
+++ b/MicroM/core/Generators/ReactGenerator/CategoriesExtensions.cs
@@ -8,6 +8,10 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.ReactGenerator
 {
+    /// <summary>
+    /// Provides helpers for generating TypeScript code related to entity
+    /// categories when building the React client.
+    /// </summary>
     public static class CategoriesExtensions
     {
         private static void AppendLookupDefinitionContentCategories(this StringBuilder sb, ColumnBase col, string indent = $"{TAB}")
@@ -20,6 +24,12 @@ namespace MicroM.Generators.ReactGenerator
             sb.Append(CultureInfo.InvariantCulture, $"\n{indent}{TAB}}}");
         }
 
+        /// <summary>
+        /// Builds the lookup definition block for category columns.
+        /// </summary>
+        /// <param name="cols">Collection of columns to inspect for category relationships.</param>
+        /// <param name="indent">Indentation used in the generated template.</param>
+        /// <returns>TypeScript code containing lookup definitions for categories.</returns>
         public static string AsLookupDefinitionContentCategories(this IReadonlyOrderedDictionary<ColumnBase> cols, string indent = $"{TAB}")
         {
             var cols_enumerator = cols.Values.Where(column => string.IsNullOrEmpty(column.RelatedCategoryID) == false).GetEnumerator();
@@ -40,6 +50,11 @@ namespace MicroM.Generators.ReactGenerator
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Generates the list of category entities that need to be imported.
+        /// </summary>
+        /// <param name="cols">Collection of columns to inspect for category relationships.</param>
+        /// <returns>A comma separated list of category entity imports.</returns>
         public static string AsEmbeddedCategoriesImport(this IReadonlyOrderedDictionary<ColumnBase> cols)
         {
             var relatedCategories = string.Join(", ",
@@ -72,6 +87,12 @@ namespace MicroM.Generators.ReactGenerator
             return Templates.CATEGORY_ENTITY_TEMPLATE.ReplaceTemplate(parms);
         }
 
+        /// <summary>
+        /// Creates TypeScript entity classes for the categories referenced by the columns.
+        /// </summary>
+        /// <param name="cols">Collection of columns that may reference categories.</param>
+        /// <param name="categories_types">Dictionary mapping category identifiers to their definition types.</param>
+        /// <returns>TypeScript code defining the category entities.</returns>
         public static string AsCategoriesEntities(this IReadonlyOrderedDictionary<ColumnBase> cols, Dictionary<string, Type> categories_types)
         {
             var cols_enumerator = cols.Values.Where(column => string.IsNullOrEmpty(column.RelatedCategoryID) == false).GetEnumerator();

--- a/MicroM/core/Generators/ReactGenerator/ColumnExtensions.cs
+++ b/MicroM/core/Generators/ReactGenerator/ColumnExtensions.cs
@@ -9,13 +9,28 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.ReactGenerator
 {
+    /// <summary>
+    /// Extension methods for translating column metadata into TypeScript
+    /// definitions and form controls for the React client.
+    /// </summary>
     public static class ColumnExtensions
     {
+        /// <summary>
+        /// Converts a column name into a human friendly display string.
+        /// </summary>
+        /// <param name="column">Column whose name will be formatted.</param>
+        /// <returns>The formatted display name.</returns>
         public static string AsDisplayName(this ColumnBase column)
         {
             return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(column.Name.StripColumnPrefix().Replace('_', ' '));
         }
 
+        /// <summary>
+        /// Converts <see cref="ColumnFlags"/> into the corresponding
+        /// TypeScript flag representation.
+        /// </summary>
+        /// <param name="flags">Flags to convert.</param>
+        /// <returns>String containing the TypeScript flag expression.</returns>
         internal static string ToTypeScriptFlags(this ColumnFlags flags)
         {
             if (flags == ColumnFlags.None) return "EntityColumnFlags.None";
@@ -105,6 +120,13 @@ namespace MicroM.Generators.ReactGenerator
             return $"//ERROR: can't translate column definition for {col.Name}. Reason: Unsupported type {m.SQLType}";
         }
 
+        /// <summary>
+        /// Builds the TypeScript column definition block for an entity.
+        /// </summary>
+        /// <typeparam name="T">Dictionary type containing column definitions.</typeparam>
+        /// <param name="cols">Columns to translate.</param>
+        /// <param name="separator">Separator used between generated lines.</param>
+        /// <returns>TypeScript code for the column definitions.</returns>
         internal static string AsTypeScriptColumnsDefinition<T>(this T cols, string separator = $",\n{TAB}{TAB}") where T : IReadonlyOrderedDictionary<ColumnBase>
         {
             IEnumerator<ColumnBase> col_enumerator = cols.GetWithFlags(ColumnFlags.All, exclude_flags: ColumnFlags.None, exclude_names: SystemColumnNames.AsStringArray).GetEnumerator();
@@ -124,6 +146,12 @@ namespace MicroM.Generators.ReactGenerator
             return colsBuilder.ToString();
         }
 
+        /// <summary>
+        /// Determines which form field components need to be imported based on the column types.
+        /// </summary>
+        /// <typeparam name="T">Dictionary type containing column definitions.</typeparam>
+        /// <param name="cols">Columns to analyze.</param>
+        /// <returns>A comma separated list of component names.</returns>
         internal static string AsFieldsImport<T>(this T cols) where T : IReadonlyOrderedDictionary<ColumnBase>
         {
             if (cols.Count == 0) return "";
@@ -182,6 +210,13 @@ namespace MicroM.Generators.ReactGenerator
             return fieldsImport.ToString().TrimEnd(',', ' ');
         }
 
+        /// <summary>
+        /// Generates a lookup select or multi-select control for the specified column.
+        /// </summary>
+        /// <typeparam name="T">Type of the column.</typeparam>
+        /// <param name="column">Column definition.</param>
+        /// <param name="separator">Separator used before the generated control.</param>
+        /// <returns>TypeScript JSX for the lookup control.</returns>
         internal static string AsLookupSelect<T>(this T column, string separator = $"\n{TAB}{TAB}{TAB}{TAB}") where T : ColumnBase
         {
             string sep = $"{separator}{TAB}";
@@ -196,6 +231,14 @@ namespace MicroM.Generators.ReactGenerator
             }
         }
 
+        /// <summary>
+        /// Builds the appropriate form field control for a column.
+        /// </summary>
+        /// <typeparam name="T">Type of the column.</typeparam>
+        /// <param name="column">Column definition.</param>
+        /// <param name="autoFocus">Whether the control should autofocus.</param>
+        /// <param name="separator">Separator used before the generated control.</param>
+        /// <returns>TypeScript JSX representing the form control.</returns>
         internal static string AsFormField<T>(this T column, bool autoFocus = false, string separator = "\n                ") where T : ColumnBase
         {
             bool autoNum = column.ColumnMetadata.HasFlag(ColumnFlags.Autonum);
@@ -256,6 +299,13 @@ namespace MicroM.Generators.ReactGenerator
 
         }
 
+        /// <summary>
+        /// Builds the collection of form field controls for all columns.
+        /// </summary>
+        /// <typeparam name="T">Dictionary type containing column definitions.</typeparam>
+        /// <param name="cols">Columns to translate into form controls.</param>
+        /// <param name="separator">Separator used between each field control.</param>
+        /// <returns>Combined TypeScript JSX for the form controls.</returns>
         internal static string AsTypeScriptFieldsControls<T>(this T cols, string separator = $"\n{TAB}{TAB}{TAB}{TAB}") where T : IReadonlyOrderedDictionary<ColumnBase>
         {
             IEnumerator<ColumnBase> col_enumerator = cols.GetWithFlags(ColumnFlags.All, exclude_flags: ColumnFlags.None, exclude_names: SystemColumnNames.AsStringArray).GetEnumerator();

--- a/MicroM/core/Generators/ReactGenerator/EntityExtensions.cs
+++ b/MicroM/core/Generators/ReactGenerator/EntityExtensions.cs
@@ -4,11 +4,17 @@ using MicroM.Generators.Extensions;
 namespace MicroM.Generators.ReactGenerator
 {
     /// <summary>
-    /// Extensions for generating react entities
+    /// Extension methods for generating TypeScript code for React client
+    /// entities.
     /// </summary>
     public static class EntityExtensions
     {
-
+        /// <summary>
+        /// Creates the TypeScript entity definition class for the specified entity.
+        /// </summary>
+        /// <typeparam name="T">Type of the entity.</typeparam>
+        /// <param name="entity">Entity used to build the definition.</param>
+        /// <returns>TypeScript code for the entity definition.</returns>
         public static string AsTypeScriptEntityDefinition<T>(this T entity) where T : EntityBase
         {
             string lookup_definitions = entity.Def.AsLookupDefinition();
@@ -33,6 +39,12 @@ namespace MicroM.Generators.ReactGenerator
             return Templates.ENTITY_DEFINITION_TEMPLATE.ReplaceTemplate(parms).RemoveEmptyLines();
         }
 
+        /// <summary>
+        /// Creates the TypeScript entity class for the specified entity definition.
+        /// </summary>
+        /// <typeparam name="T">Type of the entity.</typeparam>
+        /// <param name="entity">Entity used to generate the class.</param>
+        /// <returns>TypeScript code for the entity class.</returns>
         public static string AsTypeScriptEntity<T>(this T entity) where T : EntityBase
         {
             var parms = new TemplateValues()
@@ -46,6 +58,12 @@ namespace MicroM.Generators.ReactGenerator
 
 
         //-----------------------------------------------------------------------------------------------------------------------------
+        /// <summary>
+        /// Generates the React form component for the entity.
+        /// </summary>
+        /// <typeparam name="T">Type of the entity.</typeparam>
+        /// <param name="entity">Entity for which to build the form.</param>
+        /// <returns>TypeScript code for the entity form component.</returns>
         public static string AsTypeScriptEntityForm<T>(this T entity) where T : EntityBase
         {
             var parms = new TemplateValues()

--- a/MicroM/core/Generators/ReactGenerator/LookupExtensions.cs
+++ b/MicroM/core/Generators/ReactGenerator/LookupExtensions.cs
@@ -7,6 +7,10 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.ReactGenerator
 {
+    /// <summary>
+    /// Extension methods for generating lookup related TypeScript code for
+    /// the React client.
+    /// </summary>
     public static class LookupExtensions
     {
         private static void AppendDefaultLookupDefinition(this StringBuilder sb, EntityForeignKeyBase fk, string indent)
@@ -17,6 +21,12 @@ namespace MicroM.Generators.ReactGenerator
             sb.Append(CultureInfo.InvariantCulture, $"\n{indent}{TAB}}}");
         }
 
+        /// <summary>
+        /// Generates lookup definitions for default foreign key relationships.
+        /// </summary>
+        /// <param name="foreign_keys">Foreign keys to inspect.</param>
+        /// <param name="indent">Indentation used in the generated template.</param>
+        /// <returns>TypeScript code describing the default lookup definitions.</returns>
         public static string AsDefaultLookupDefinitionContent(this IReadOnlyDictionary<string, EntityForeignKeyBase> foreign_keys, string indent = $"{TAB}")
         {
             var lookups_enumerator = foreign_keys.Values.GetEnumerator();
@@ -47,6 +57,12 @@ namespace MicroM.Generators.ReactGenerator
             sb.Append(CultureInfo.InvariantCulture, $"\n{indent}{TAB}}}");
         }
 
+        /// <summary>
+        /// Generates lookup definitions for the entity's explicit lookup configurations.
+        /// </summary>
+        /// <param name="foreign_keys">Foreign keys containing lookup settings.</param>
+        /// <param name="indent">Indentation used in the generated template.</param>
+        /// <returns>TypeScript code with lookup definition entries.</returns>
         public static string AsLookupDefinitionContent(this IReadOnlyDictionary<string, EntityForeignKeyBase> foreign_keys, string indent = $"{TAB}")
         {
             var lookups_enumerator = foreign_keys.Values.SelectMany(
@@ -70,6 +86,12 @@ namespace MicroM.Generators.ReactGenerator
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Builds the complete lookup definition block for an entity definition.
+        /// </summary>
+        /// <param name="def">Entity definition whose lookups will be described.</param>
+        /// <param name="indent">Indentation used in the generated template.</param>
+        /// <returns>TypeScript code containing the lookup definitions or an empty string.</returns>
         public static string AsLookupDefinition(this EntityDefinition def, string indent = $"{TAB}")
         {
             string? fk_default_lookups = def.ForeignKeys.Count > 0 ? def.ForeignKeys.AsDefaultLookupDefinitionContent() : null;

--- a/MicroM/core/Generators/ReactGenerator/ProcsExtensions.cs
+++ b/MicroM/core/Generators/ReactGenerator/ProcsExtensions.cs
@@ -6,9 +6,19 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.ReactGenerator
 {
+    /// <summary>
+    /// Extension methods for generating stored procedure definitions in
+    /// React client templates.
+    /// </summary>
     public static class ProcsExtensions
     {
 
+        /// <summary>
+        /// Creates the TypeScript block defining stored procedures for an entity.
+        /// </summary>
+        /// <param name="def">Entity definition containing procedure metadata.</param>
+        /// <param name="indent">Indentation used in the generated template.</param>
+        /// <returns>TypeScript code describing the procedures or an empty string.</returns>
         public static string AsProcsDefinition(this EntityDefinition def, string indent = $"{TAB}")
         {
             if(def.Procs.Count == 0) return "";

--- a/MicroM/core/Generators/ReactGenerator/TemplateValues.cs
+++ b/MicroM/core/Generators/ReactGenerator/TemplateValues.cs
@@ -1,33 +1,70 @@
 ﻿namespace MicroM.Generators.ReactGenerator
 {
+    /// <summary>
+    /// Token values used for replacing placeholders in React generator templates.
+    /// </summary>
     internal class TemplateValues : TemplateValuesBase
     {
+        /// <summary>
+        /// Default npm package name for the MicroM library.
+        /// </summary>
         public const string CONST_MICROM_LIB_PACKAGE = "@mcurros2/microm";
+        /// <summary>
+        /// Tokens used when importing lookup utilities.
+        /// </summary>
         public const string CONST_ENTITY_LOOKUP_IMPORT = ", MicroMClient, ValuesObject";
+        /// <summary>
+        /// Statement assigning lookup definitions within a template.
+        /// </summary>
         public const string CONST_LOOKUPS_ASSIGNMENT = "lookups = lookups();";
+        /// <summary>
+        /// Statement assigning procedure definitions within a template.
+        /// </summary>
         public const string CONST_PROCS_ASSIGNMENT = "procs = procs();";
 
+        /// <summary>Token for the MNEO identifier.</summary>
         public string MNEO { get => tokens[nameof(MNEO)]; init => tokens[nameof(MNEO)] = value; }
+        /// <summary>Token for column definitions.</summary>
         public string COLUMNS_DEFINITION { get => tokens[nameof(COLUMNS_DEFINITION)]; init => tokens[nameof(COLUMNS_DEFINITION)] = value; }
+        /// <summary>Token for view key mappings.</summary>
         public string VIEW_KEY_MAPPINGS { get => tokens[nameof(VIEW_KEY_MAPPINGS)]; init => tokens[nameof(VIEW_KEY_MAPPINGS)] = value; }
+        /// <summary>Token for lookup definitions within an entity.</summary>
         public string ENTITY_LOOKUPS_DEFINITION { get => tokens[nameof(ENTITY_LOOKUPS_DEFINITION)]; init => tokens[nameof(ENTITY_LOOKUPS_DEFINITION)] = value; }
+        /// <summary>Token for the entity class name.</summary>
         public string ENTITY_CLASSNAME { get => tokens[nameof(ENTITY_CLASSNAME)]; init => tokens[nameof(ENTITY_CLASSNAME)] = value; }
+        /// <summary>Token for assigning lookup definitions to an entity.</summary>
         public string ENTITY_LOOKUPS_ASSIGNMENT { get => tokens[nameof(ENTITY_LOOKUPS_ASSIGNMENT)]; init => tokens[nameof(ENTITY_LOOKUPS_ASSIGNMENT)] = value; }
+        /// <summary>Token for embedding a form component.</summary>
         public string ENTITY_FORM { get => tokens[nameof(ENTITY_FORM)]; init => tokens[nameof(ENTITY_FORM)] = value; }
+        /// <summary>Token for additional lookup imports.</summary>
         public string ENTITY_LOOKUP_IMPORT { get => tokens[nameof(ENTITY_LOOKUP_IMPORT)]; init => tokens[nameof(ENTITY_LOOKUP_IMPORT)] = value; }
+        /// <summary>Token for the views definition block.</summary>
         public string VIEWS_DEFINITION { get => tokens[nameof(VIEWS_DEFINITION)]; init => tokens[nameof(VIEWS_DEFINITION)] = value; }
+        /// <summary>Token for a procedure name.</summary>
         public string PROC_NAME { get => tokens[nameof(PROC_NAME)]; init => tokens[nameof(PROC_NAME)] = value; }
+        /// <summary>Token for lookup definitions.</summary>
         public string LOOKUPS_DEFINITION { get => tokens[nameof(LOOKUPS_DEFINITION)]; init => tokens[nameof(LOOKUPS_DEFINITION)] = value; }
+        /// <summary>Token for the MicroM library package name.</summary>
         public string MICROM_LIB_PACKAGE { get => tokens[nameof(MICROM_LIB_PACKAGE)]; init => tokens[nameof(MICROM_LIB_PACKAGE)] = value; }
+        /// <summary>Token for embedded category imports.</summary>
         public string EMBEDDED_CATEGORIES_IMPORT { get => tokens[nameof(EMBEDDED_CATEGORIES_IMPORT)]; init => tokens[nameof(EMBEDDED_CATEGORIES_IMPORT)] = value; }
+        /// <summary>Token for the category identifier.</summary>
         public string CATEGORY_ID { get => tokens[nameof(CATEGORY_ID)]; init => tokens[nameof(CATEGORY_ID)] = value; }
+        /// <summary>Token for related category entity definitions.</summary>
         public string RELATED_CATEGORIES_ENTITIES { get => tokens[nameof(RELATED_CATEGORIES_ENTITIES)]; init => tokens[nameof(RELATED_CATEGORIES_ENTITIES)] = value; }
+        /// <summary>Token for the category title.</summary>
         public string CATEGORY_TITLE { get => tokens[nameof(CATEGORY_TITLE)]; init => tokens[nameof(CATEGORY_TITLE)] = value; }
+        /// <summary>Token listing field components to import.</summary>
         public string FIELDS_IMPORT { get => tokens[nameof(FIELDS_IMPORT)]; init => tokens[nameof(FIELDS_IMPORT)] = value; }
+        /// <summary>Token containing JSX for form controls.</summary>
         public string FIELDS_CONTROLS { get => tokens[nameof(FIELDS_CONTROLS)]; init => tokens[nameof(FIELDS_CONTROLS)] = value; }
+        /// <summary>Token for the entity title text.</summary>
         public string ENTITY_TITLE { get => tokens[nameof(ENTITY_TITLE)]; init => tokens[nameof(ENTITY_TITLE)] = value; }
+        /// <summary>Token for procedure definitions assigned to an entity.</summary>
         public string ENTITY_PROC_DEFINITIONS { get => tokens[nameof(ENTITY_PROC_DEFINITIONS)]; init => tokens[nameof(ENTITY_PROC_DEFINITIONS)] = value; }
+        /// <summary>Token for the procedures definition block.</summary>
         public string PROCS_DEFINITION { get => tokens[nameof(PROCS_DEFINITION)]; init => tokens[nameof(PROCS_DEFINITION)] = value; }
+        /// <summary>Token assigning procedure definitions to an entity.</summary>
         public string ENTITY_PROCS_ASSIGNMENT { get => tokens[nameof(ENTITY_PROCS_ASSIGNMENT)]; init => tokens[nameof(ENTITY_PROCS_ASSIGNMENT)] = value; }
 
     }

--- a/MicroM/core/Generators/ReactGenerator/Templates.cs
+++ b/MicroM/core/Generators/ReactGenerator/Templates.cs
@@ -1,7 +1,13 @@
 ﻿namespace MicroM.Generators.ReactGenerator
 {
+    /// <summary>
+    /// Holds TypeScript template strings used to generate React client files.
+    /// </summary>
     internal class Templates
     {
+        /// <summary>
+        /// Template for a category entity class.
+        /// </summary>
         internal const string CATEGORY_ENTITY_TEMPLATE =
 @"
 import { CategoriesValues, MicroMClient } from ""{MICROM_LIB_PACKAGE}"";
@@ -24,6 +30,9 @@ export class cat{CATEGORY_ID} extends CategoriesValues {
 
 ";
 
+        /// <summary>
+        /// Template for the lookup definition function of an entity.
+        /// </summary>
         internal const string ENTITY_LOOKUPS_TEMPLATE =
 @"
 const lookups = () =>
@@ -32,6 +41,9 @@ const lookups = () =>
 )
 ";
 
+        /// <summary>
+        /// Template for the stored procedure definition function of an entity.
+        /// </summary>
         internal const string ENTITY_PROCS_TEMPLATE =
 @"
 const procs = () =>
@@ -40,6 +52,9 @@ const procs = () =>
 )
 ";
 
+        /// <summary>
+        /// Template for the TypeScript entity definition class.
+        /// </summary>
         internal const string ENTITY_DEFINITION_TEMPLATE =
 @"
 import { DefaultColumns, EntityColumn, EntityDefinition{ENTITY_LOOKUP_IMPORT}, EntityColumnFlags, CommonFlags as c } from ""{MICROM_LIB_PACKAGE}"";
@@ -73,6 +88,9 @@ export class {ENTITY_CLASSNAME}Def extends EntityDefinition {
 }
 ";
 
+        /// <summary>
+        /// Template for the TypeScript entity class.
+        /// </summary>
         internal const string ENTITY_TEMPLATE =
 @"
 import { Entity, MicroMClient } from ""{MICROM_LIB_PACKAGE}"";
@@ -93,6 +111,9 @@ export class {ENTITY_CLASSNAME} extends Entity<{ENTITY_CLASSNAME}Def> {
 }
 ";
 
+        /// <summary>
+        /// Template for the React form component associated with an entity.
+        /// </summary>
         internal const string ENTITY_FORM_TEMPLATE =
 @"
 import { Stack, useComponentDefaultProps, useMantineTheme } from ""@mantine/core"";

--- a/MicroM/core/Generators/ReactGenerator/ViewExtensions.cs
+++ b/MicroM/core/Generators/ReactGenerator/ViewExtensions.cs
@@ -5,8 +5,17 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.ReactGenerator
 {
+    /// <summary>
+    /// Extension methods for generating view related TypeScript code for
+    /// the React client.
+    /// </summary>
     public static class ViewExtensions
     {
+        /// <summary>
+        /// Creates the key mapping portion of a view definition.
+        /// </summary>
+        /// <param name="view">View definition to translate.</param>
+        /// <returns>A comma separated list of key mappings.</returns>
         internal static string AsKeyMappings(this ViewDefinition view)
         {
             var parms_enumerator = view.Parms.Values.GetEnumerator();
@@ -26,6 +35,12 @@ namespace MicroM.Generators.ReactGenerator
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Builds the TypeScript object that defines the entity views.
+        /// </summary>
+        /// <param name="views">Collection of view definitions.</param>
+        /// <param name="indent">Indentation used in the generated template.</param>
+        /// <returns>TypeScript code describing the views.</returns>
         public static string AsViewsDefinition(this IReadOnlyDictionary<string, ViewDefinition> views, string indent = $"{TAB}")
         {
             IEnumerator<ViewDefinition> views_enumerator = views.Values.GetEnumerator();


### PR DESCRIPTION
## Summary
- add XML documentation to React generator extension classes
- document template strings and token properties

## Testing
- `dotnet test` *(fails: /usr/bin/sh: del: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f9781a448324a433d506c349d943