### PR TITLE
docs: document DebugRoutesMiddleware

### DIFF
--- a/MicroM/core/Web/Debugging/DebugRoutesMiddleware.cs
+++ b/MicroM/core/Web/Debugging/DebugRoutesMiddleware.cs
@@ -15,8 +15,11 @@ namespace MicroM.Web.Middleware
         private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions() { WriteIndented = true };
 
         /// <summary>
-        /// Performs the DebugRoutesMiddleware operation.
+        /// Initializes a new instance of the <see cref="DebugRoutesMiddleware"/> that exposes
+        /// route information at a specified debugging endpoint.
         /// </summary>
+        /// <param name="next">The next middleware delegate in the pipeline.</param>
+        /// <param name="debugRoutesURL">The request path that triggers route debugging.</param>
         public DebugRoutesMiddleware(RequestDelegate next, string debugRoutesURL)
         {
             _next = next;
@@ -24,8 +27,13 @@ namespace MicroM.Web.Middleware
         }
 
         /// <summary>
-        /// Performs the Invoke operation.
+        /// Intercepts requests to the configured debug route URL and writes a JSON array
+        /// describing all known MVC routes to the response; otherwise, the request is
+        /// forwarded to the next middleware.
         /// </summary>
+        /// <param name="context">The current HTTP context.</param>
+        /// <param name="provider">Provides the collection of MVC action descriptors used to build the route listing.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
         public async Task Invoke(HttpContext context, IActionDescriptorCollectionProvider? provider)
         {
             if (context.Request.Path == _debugRoutesURL)


### PR DESCRIPTION
## Summary
- add constructor and Invoke method XML comments to DebugRoutesMiddleware

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9065b4cc883249de5048f2a1e3c8f