### PR TITLE
Add XML docs for file upload and email services

### DIFF
--- a/MicroM/core/Web/Services/FileUploadService/FileUploadService.cs
+++ b/MicroM/core/Web/Services/FileUploadService/FileUploadService.cs
@@ -23,6 +23,18 @@ namespace MicroM.Web.Services
         private readonly IThumbnailService _thumbnailService = thumbnailService;
         private bool disposedValue;
 
+        /// <summary>
+        /// Queues metadata for an incoming file and prepares its destination path.
+        /// </summary>
+        /// <param name="app_id">Application identifier.</param>
+        /// <param name="fileprocess_id">Process identifier associated with the file.</param>
+        /// <param name="file_name">Original name of the uploaded file.</param>
+        /// <param name="ec">Entity client used for database access.</param>
+        /// <param name="ct">Token to observe for cancellation.</param>
+        /// <returns>
+        /// A tuple containing an error message, the <see cref="FileStore"/> record,
+        /// the full file path, and the file extension.
+        /// </returns>
         private async Task<(string? errorMessage, FileStore? file_store, string? fullPath, string? extension)>
             QueueFile(string app_id, string fileprocess_id, string file_name, IEntityClient ec, CancellationToken ct)
         {


### PR DESCRIPTION
## Summary
- document QueueFile helper for file uploads
- improve email queue status updates and SendEmail docs

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: /workspace/MicroMFramework/MicroM/core/MicroMCore.csproj(180,5): error MSB3073: The command "del /Q \"bin/Debug/*.nupkg\"" exited with code 127.)*

------
https://chatgpt.com/codex/tasks/task_e_68a90ef6af7083249f44b61db03c293e