### PR TITLE
Clarify null handling in lookup description property

### DIFF
--- a/MicroM/core/Data/LookupResult.cs
+++ b/MicroM/core/Data/LookupResult.cs
@@ -8,7 +8,10 @@
     {
         /// <summary>
         /// Gets or sets the descriptive text returned by the lookup. UI components
-        /// consume this value to show user-friendly text for a provided key.
+        /// consume this value to show user-friendly text for a provided key. The value may
+        /// be <see langword="null"/> when the lookup cannot resolve a description for the
+        /// supplied key; callers should handle this by checking for <see langword="null"/>
+        /// and substituting a placeholder or omitting the text as appropriate.
         /// </summary>
         public string? Description { get; set; } = null;
     }


### PR DESCRIPTION
## Summary
- elaborate when `LookupResult.Description` may be `null`
- advise callers to handle a missing description gracefully

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: /usr/bin/sh: del: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1e9e0c8883249e92e79832dc6f1b