### PR TITLE
Improve authentication XML documentation

### DIFF
--- a/MicroM/core/Web/Authentication/AuthenticationProvider/AuthenticatorResult.cs
+++ b/MicroM/core/Web/Authentication/AuthenticationProvider/AuthenticatorResult.cs
@@ -4,32 +4,37 @@ using Microsoft.AspNetCore.Identity;
 namespace MicroM.Web.Authentication
 {
     /// <summary>
-    /// Represents the AuthenticatorResult.
+    /// Represents the outcome of an authentication attempt.
     /// </summary>
     public class AuthenticatorResult
     {
         /// <summary>
-        /// false; field.
+        /// Indicates whether the user's account is disabled. Defaults to <see langword="false"/>.
         /// </summary>
         public bool AccountDisabled = false;
+
         /// <summary>
-        /// false; field.
+        /// Indicates whether the user's account is locked. Defaults to <see langword="false"/>.
         /// </summary>
         public bool AccountLocked = false;
+
         /// <summary>
-        /// PasswordVerificationResult.Failed; field.
+        /// Result of verifying the supplied password. Initialized to <see cref="PasswordVerificationResult.Failed"/>.
         /// </summary>
         public PasswordVerificationResult PasswordVerificationResult = PasswordVerificationResult.Failed;
+
         /// <summary>
-        /// null; field.
+        /// User login information associated with the authentication attempt, if available.
         /// </summary>
         public LoginData? LoginData = null;
+
         /// <summary>
-        /// Performs the new operation.
+        /// Collection of decrypted server-side claims returned by the authenticator.
         /// </summary>
         public Dictionary<string, object> ServerClaims = new(StringComparer.OrdinalIgnoreCase);
+
         /// <summary>
-        /// Performs the new operation.
+        /// Collection of client-side claims to be issued to the caller.
         /// </summary>
         public Dictionary<string, string> ClientClaims = new(StringComparer.OrdinalIgnoreCase);
     }

--- a/MicroM/core/Web/Authentication/AuthenticationProvider/IAuthenticationProvider.cs
+++ b/MicroM/core/Web/Authentication/AuthenticationProvider/IAuthenticationProvider.cs
@@ -5,17 +5,24 @@ using MicroM.Web.Services;
 namespace MicroM.Web.Authentication;
 
 /// <summary>
-/// Represents the IAuthenticationProvider.
+/// Resolves authenticators and assists with claim handling for applications.
 /// </summary>
 public interface IAuthenticationProvider
 {
     /// <summary>
-    /// Performs the GetAuthenticator operation.
+    /// Retrieves an <see cref="IAuthenticator"/> implementation based on the application configuration.
     /// </summary>
-    public abstract IAuthenticator? GetAuthenticator(ApplicationOption app_config);
-    /// <summary>
-    /// Performs the GetAppAndUnencryptClaims operation.
-    /// </summary>
-    ApplicationOption? GetAppAndUnencryptClaims(IMicroMAppConfiguration app_config, string app_id, DataWebAPIRequest parms, Dictionary<string, object>? claims);
+    /// <param name="app_config">Application options describing the authentication scheme.</param>
+    /// <returns>The matching authenticator instance, or <see langword="null"/> if none is available.</returns>
+    IAuthenticator? GetAuthenticator(ApplicationOption app_config);
 
+    /// <summary>
+    /// Obtains application configuration data and decrypts any supplied server claims.
+    /// </summary>
+    /// <param name="app_config">Access to configured application options.</param>
+    /// <param name="app_id">The identifier of the application.</param>
+    /// <param name="parms">The request parameters where decrypted claims will be stored.</param>
+    /// <param name="claims">Encrypted server claims to be decrypted.</param>
+    /// <returns>The application configuration, or <see langword="null"/> if the application cannot be found.</returns>
+    ApplicationOption? GetAppAndUnencryptClaims(IMicroMAppConfiguration app_config, string app_id, DataWebAPIRequest parms, Dictionary<string, object>? claims);
 }

--- a/MicroM/core/Web/Authentication/AuthenticationProvider/IAuthenticator.cs
+++ b/MicroM/core/Web/Authentication/AuthenticationProvider/IAuthenticator.cs
@@ -4,46 +4,72 @@ using MicroM.DataDictionary.Entities.MicromUsers;
 namespace MicroM.Web.Authentication;
 
 /// <summary>
-/// Represents the IAuthenticator.
+/// Defines the contract for authenticators capable of handling login, token refresh,
+/// password recovery and related operations.
 /// </summary>
 public interface IAuthenticator
 {
     /// <summary>
-    /// "RECOVERY"; field.
+    /// Identifier of the email template used for password recovery messages.
     /// </summary>
     public const string AuthenticatorRecoveryEmailTemplateID = "RECOVERY";
+
     /// <summary>
-    /// Gets or sets the "RECOVERY_CODE}";.
+    /// Placeholder tag within the recovery email template that is replaced with the recovery code.
     /// </summary>
     public const string AuthenticatorRecoveryEmailTemplateCodeTAG = "{RECOVERY_CODE}";
 
     /// <summary>
-    /// Performs the AuthenticateLogin operation.
+    /// Authenticates a user based on the provided login information.
     /// </summary>
-    public abstract Task<AuthenticatorResult> AuthenticateLogin(ApplicationOption app_config, UserLogin user_login, CancellationToken ct);
+    /// <param name="app_config">Application configuration containing authentication options.</param>
+    /// <param name="user_login">Credentials supplied by the user.</param>
+    /// <param name="ct">Token used to observe cancellation requests.</param>
+    /// <returns>The result of the authentication attempt.</returns>
+    Task<AuthenticatorResult> AuthenticateLogin(ApplicationOption app_config, UserLogin user_login, CancellationToken ct);
 
     /// <summary>
-    /// Performs the AuthenticateRefresh operation.
+    /// Validates the specified refresh token and issues a new token set.
     /// </summary>
-    public abstract Task<RefreshTokenResult> AuthenticateRefresh(ApplicationOption app_config, string user_id, string refresh_token, string local_device_id, CancellationToken ct);
+    /// <param name="app_config">Application configuration containing authentication options.</param>
+    /// <param name="user_id">Identifier of the user requesting the refresh.</param>
+    /// <param name="refresh_token">The refresh token to validate.</param>
+    /// <param name="local_device_id">Identifier of the device requesting the refresh.</param>
+    /// <param name="ct">Token used to observe cancellation requests.</param>
+    /// <returns>The refresh operation result.</returns>
+    Task<RefreshTokenResult> AuthenticateRefresh(ApplicationOption app_config, string user_id, string refresh_token, string local_device_id, CancellationToken ct);
 
     /// <summary>
-    /// Performs the Logoff operation.
+    /// Logs the specified user out of the system.
     /// </summary>
-    public abstract Task Logoff(ApplicationOption app_config, string user_name, CancellationToken ct);
+    /// <param name="app_config">Application configuration containing authentication options.</param>
+    /// <param name="user_name">Name of the user to log off.</param>
+    /// <param name="ct">Token used to observe cancellation requests.</param>
+    Task Logoff(ApplicationOption app_config, string user_name, CancellationToken ct);
 
     /// <summary>
-    /// Performs the UnencryptClaims operation.
+    /// Decrypts the provided collection of server claims.
     /// </summary>
-    public abstract void UnencryptClaims(Dictionary<string, object>? server_claims);
+    /// <param name="server_claims">Encrypted claims to decrypt in place.</param>
+    void UnencryptClaims(Dictionary<string, object>? server_claims);
 
     /// <summary>
-    /// Performs the Task< operation.
+    /// Sends a password recovery email to the specified user.
     /// </summary>
-    public abstract Task<(bool failed, string? error_message)> SendPasswordRecoveryEmail(ApplicationOption app_config, string user_name, CancellationToken ct);
+    /// <param name="app_config">Application configuration containing authentication options.</param>
+    /// <param name="user_name">Name of the user requesting password recovery.</param>
+    /// <param name="ct">Token used to observe cancellation requests.</param>
+    /// <returns>A tuple indicating whether the operation failed and an optional error message.</returns>
+    Task<(bool failed, string? error_message)> SendPasswordRecoveryEmail(ApplicationOption app_config, string user_name, CancellationToken ct);
 
     /// <summary>
-    /// Performs the Task< operation.
+    /// Resets the user's password using a previously issued recovery code.
     /// </summary>
-    public abstract Task<(bool failed, string? error_message)> RecoverPassword(ApplicationOption app_config, string user_name, string new_password, string recovery_code, CancellationToken ct);
+    /// <param name="app_config">Application configuration containing authentication options.</param>
+    /// <param name="user_name">Name of the user whose password is being reset.</param>
+    /// <param name="new_password">The new password to set.</param>
+    /// <param name="recovery_code">Recovery code sent to the user.</param>
+    /// <param name="ct">Token used to observe cancellation requests.</param>
+    /// <returns>A tuple indicating whether the operation failed and an optional error message.</returns>
+    Task<(bool failed, string? error_message)> RecoverPassword(ApplicationOption app_config, string user_name, string new_password, string recovery_code, CancellationToken ct);
 }

--- a/MicroM/core/Web/Authentication/AuthenticationProvider/MicroMAuthenticationProvider.cs
+++ b/MicroM/core/Web/Authentication/AuthenticationProvider/MicroMAuthenticationProvider.cs
@@ -7,16 +7,21 @@ using Microsoft.Extensions.Logging;
 namespace MicroM.Web.Authentication;
 
 /// <summary>
-/// Represents the MicroMAuthenticationProvider.
+/// Provides access to different <see cref="IAuthenticator"/> implementations based on
+/// application configuration and assists with claim handling.
 /// </summary>
+/// <param name="log">Logger used for diagnostic messages.</param>
+/// <param name="services">Collection of registered authenticators.</param>
 public class MicroMAuthenticationProvider(ILogger<MicroMAuthenticationProvider> log, IEnumerable<IAuthenticator> services) : IAuthenticationProvider
 {
     private IEnumerable<IAuthenticator> _services = services;
     private readonly ILogger<MicroMAuthenticationProvider> _log = log;
 
     /// <summary>
-    /// Performs the GetAuthenticator operation.
+    /// Retrieves an authenticator based on the application's configured authentication type.
     /// </summary>
+    /// <param name="app_config">Application options describing the authentication scheme.</param>
+    /// <returns>The matching authenticator instance, or <see langword="null"/> if none is found.</returns>
     public IAuthenticator? GetAuthenticator(ApplicationOption app_config)
     {
 
@@ -39,8 +44,13 @@ public class MicroMAuthenticationProvider(ILogger<MicroMAuthenticationProvider> 
     }
 
     /// <summary>
-    /// Performs the GetAppAndUnencryptClaims operation.
+    /// Retrieves application configuration by identifier and decrypts any provided server claims.
     /// </summary>
+    /// <param name="app_config">Access to configured application options.</param>
+    /// <param name="app_id">Identifier of the application.</param>
+    /// <param name="parms">Request parameters where decrypted claims will be stored.</param>
+    /// <param name="claims">Encrypted server claims to be decrypted.</param>
+    /// <returns>The application configuration, or <see langword="null"/> if not found.</returns>
     public ApplicationOption? GetAppAndUnencryptClaims(IMicroMAppConfiguration app_config, string app_id, DataWebAPIRequest parms, Dictionary<string, object>? claims)
     {
         ApplicationOption? app = app_config.GetAppConfiguration(app_id);

--- a/MicroM/core/Web/Authentication/AuthenticationProvider/UserLogin.cs
+++ b/MicroM/core/Web/Authentication/AuthenticationProvider/UserLogin.cs
@@ -1,20 +1,22 @@
 ﻿namespace MicroM.Web.Authentication
 {
     /// <summary>
-    /// Represents the UserLogin.
+    /// Represents credentials supplied by a user attempting to sign in.
     /// </summary>
     public class UserLogin
     {
         /// <summary>
-        /// Gets or sets the "";.
+        /// Gets or sets the user name used to authenticate.
         /// </summary>
         public string Username { get; set; } = "";
+
         /// <summary>
-        /// Gets or sets the "";.
+        /// Gets or sets the user's password.
         /// </summary>
         public string Password { get; set; } = "";
+
         /// <summary>
-        /// Gets or sets the "";.
+        /// Gets or sets the identifier of the device initiating the login request.
         /// </summary>
         public string LocalDeviceID { get; set; } = "";
     }

--- a/MicroM/core/Web/Authentication/AuthenticationProvider/UserRefreshTokenRequest.cs
+++ b/MicroM/core/Web/Authentication/AuthenticationProvider/UserRefreshTokenRequest.cs
@@ -1,16 +1,17 @@
 ﻿namespace MicroM.Web.Authentication
 {
     /// <summary>
-    /// Represents the UserRefreshTokenRequest.
+    /// Represents a request to obtain new access tokens using an existing refresh token.
     /// </summary>
     public class UserRefreshTokenRequest
     {
         /// <summary>
-        /// Gets or sets the "";.
+        /// Gets or sets the bearer token presented by the client.
         /// </summary>
         public string Bearer { get; set; } = "";
+
         /// <summary>
-        /// Gets or sets the "";.
+        /// Gets or sets the refresh token used to request new access tokens.
         /// </summary>
         public string RefreshToken { get; set; } = "";
     }

--- a/MicroM/core/Web/Authentication/Claims/MicroMClientClaimTypes.cs
+++ b/MicroM/core/Web/Authentication/Claims/MicroMClientClaimTypes.cs
@@ -1,16 +1,17 @@
 ﻿namespace MicroM.Web.Authentication
 {
     /// <summary>
-    /// Represents the MicroMClientClaimTypes.
+    /// Defines claim type names issued to clients.
     /// </summary>
     public class MicroMClientClaimTypes
     {
         /// <summary>
-        /// Performs the nameof operation.
+        /// Claim type for the user's name.
         /// </summary>
         public const string username = nameof(username);
+
         /// <summary>
-        /// Performs the nameof operation.
+        /// Claim type for the user's email address.
         /// </summary>
         public const string useremail = nameof(useremail);
     }

--- a/MicroM/core/Web/Authentication/Claims/MicroMServerClaimTypes.cs
+++ b/MicroM/core/Web/Authentication/Claims/MicroMServerClaimTypes.cs
@@ -1,40 +1,47 @@
 ﻿namespace MicroM.Web.Authentication
 {
     /// <summary>
-    /// Represents the MicroMServerClaimTypes.
+    /// Defines claim type names used internally by the MicroM server.
     /// </summary>
     public class MicroMServerClaimTypes
     {
         /// <summary>
-        /// Performs the nameof operation.
+        /// Claim type for the application identifier.
         /// </summary>
         public const string MicroMAPP_id = nameof(MicroMAPP_id);
+
         /// <summary>
-        /// Performs the nameof operation.
+        /// Claim type for the unique user identifier.
         /// </summary>
         public const string MicroMUser_id = nameof(MicroMUser_id);
+
         /// <summary>
-        /// Performs the nameof operation.
+        /// Claim type for the user's name.
         /// </summary>
         public const string MicroMUsername = nameof(MicroMUsername);
+
         /// <summary>
-        /// Performs the nameof operation.
+        /// Claim type indicating the MicroM server handling the request.
         /// </summary>
         public const string MicroMServer = nameof(MicroMServer);
+
         /// <summary>
-        /// Performs the nameof operation.
+        /// Claim type for the user's password or password hash.
         /// </summary>
         public const string MicroMPassword = nameof(MicroMPassword);
+
         /// <summary>
-        /// Performs the nameof operation.
+        /// Claim type for the user's role or type identifier.
         /// </summary>
         public const string MicroMUserType_id = nameof(MicroMUserType_id);
+
         /// <summary>
-        /// Performs the nameof operation.
+        /// Claim type describing the groups to which the user belongs.
         /// </summary>
         public const string MicroMUserGroups = nameof(MicroMUserGroups);
+
         /// <summary>
-        /// Performs the nameof operation.
+        /// Claim type for the identifier of the user's device.
         /// </summary>
         public const string MicroMUserDeviceID = nameof(MicroMUserDeviceID);
     }

--- a/MicroM/core/Web/Authentication/CookiesManager/MicroMCookieManager.cs
+++ b/MicroM/core/Web/Authentication/CookiesManager/MicroMCookieManager.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace MicroM.Web.Services
 {
     /// <summary>
-    /// Represents the MicroMCookieManager.
+    /// Cookie manager that scopes authentication cookies per application tenant.
     /// </summary>
     public class MicroMCookieManager : ICookieManager
     {
@@ -17,8 +17,10 @@ namespace MicroM.Web.Services
         private readonly PathString _basePathString;
 
         /// <summary>
-        /// Performs the MicroMCookieManager operation.
+        /// Initializes a new instance of the <see cref="MicroMCookieManager"/> class.
         /// </summary>
+        /// <param name="microm_config">Configuration options for the MicroM application.</param>
+        /// <param name="logger">Logger used to emit diagnostic messages.</param>
         public MicroMCookieManager(IOptions<MicroMOptions> microm_config, ILogger<MicroMCookieManager> logger)
         {
             _config = microm_config;
@@ -90,16 +92,23 @@ namespace MicroM.Web.Services
         }
 
         /// <summary>
-        /// Performs the GetRequestCookie operation.
+        /// Retrieves a cookie from the incoming request.
         /// </summary>
+        /// <param name="context">The HTTP context of the current request.</param>
+        /// <param name="key">The cookie key.</param>
+        /// <returns>The cookie value, or <see langword="null"/> if not found.</returns>
         public string? GetRequestCookie(HttpContext context, string key)
         {
             return _inner.GetRequestCookie(context, key);
         }
 
         /// <summary>
-        /// Performs the AppendResponseCookie operation.
+        /// Appends a cookie to the outgoing response, adjusting the path for the tenant when applicable.
         /// </summary>
+        /// <param name="context">The HTTP context of the current request.</param>
+        /// <param name="key">The cookie key.</param>
+        /// <param name="value">The cookie value.</param>
+        /// <param name="options">Options controlling cookie creation.</param>
         public void AppendResponseCookie(HttpContext context, string key, string? value, CookieOptions options)
         {
             var tenantPath = GetTenantPath(context);
@@ -115,8 +124,11 @@ namespace MicroM.Web.Services
         }
 
         /// <summary>
-        /// Performs the DeleteCookie operation.
+        /// Deletes a cookie from the response, adjusting the path for the tenant when applicable.
         /// </summary>
+        /// <param name="context">The HTTP context of the current request.</param>
+        /// <param name="key">The cookie key.</param>
+        /// <param name="options">Options controlling cookie deletion.</param>
         public void DeleteCookie(HttpContext context, string key, CookieOptions options)
         {
             var tenantPath = GetTenantPath(context);

--- a/MicroM/core/Web/Authentication/CookiesManager/MicroMCookiesManagerSetup.cs
+++ b/MicroM/core/Web/Authentication/CookiesManager/MicroMCookiesManagerSetup.cs
@@ -5,16 +5,20 @@ using Microsoft.Extensions.Options;
 namespace MicroM.Web.Services
 {
     /// <summary>
-    /// Represents the MicroMCookiesManagerSetup.
+    /// Applies the <see cref="MicroMCookieManager"/> to cookie authentication options after configuration.
     /// </summary>
+    /// <param name="cookieManager">The cookie manager instance to apply.</param>
+    /// <param name="logger">Logger used for diagnostic messages.</param>
     public class MicroMCookiesManagerSetup(ICookieManager cookieManager, ILogger<MicroMCookiesManagerSetup> logger) : IPostConfigureOptions<CookieAuthenticationOptions>
     {
         private readonly ICookieManager _cookieManager = cookieManager;
         private readonly ILogger<MicroMCookiesManagerSetup> _log = logger;
 
         /// <summary>
-        /// Performs the PostConfigure operation.
+        /// Sets the custom cookie manager on the provided options.
         /// </summary>
+        /// <param name="name">The name of the options instance being configured.</param>
+        /// <param name="options">The cookie authentication options to post configure.</param>
         public void PostConfigure(string? name, CookieAuthenticationOptions options)
         {
             options.CookieManager = _cookieManager;


### PR DESCRIPTION
## Summary
- enhance AuthenticatorResult to describe authentication outcomes and claim collections
- document authentication provider and authenticator interfaces
- clarify claim type and cookie manager behaviors

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: `/usr/bin/sh: ... del: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab225919f88324845219d625ec703d