### PR TITLE
docs: detail AccountLockout lockout tracking

### DIFF
--- a/MicroM/Documentation/Backend/MicroM.Web.Authentication/AccountLockout/index.md
+++ b/MicroM/Documentation/Backend/MicroM.Web.Authentication/AccountLockout/index.md
@@ -1,6 +1,6 @@
-# Class: MicroM.Web.Authentication.AccountLockout
+﻿# Class: MicroM.Web.Authentication.AccountLockout
 ## Overview
-Account Lockout class.
+Tracks failed login attempts and refresh token validation to enforce account lockouts.
 
 **Inheritance**
 object -> AccountLockout
@@ -9,5 +9,28 @@ object -> AccountLockout
 None
 
 ## Remarks
-None.
+Used by SQLServerAuthenticator to cache lockout state and evaluate login attempts.
 
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| BadLogonAttempts | int | Count of consecutive failed logins; more than ten locks the account. |
+| LockedUntil | DateTime? | When the current lockout expires; null means no lock. |
+| RefreshToken | string? | Refresh token issued for the account. |
+| RefreshTokenExpiration | DateTime? | Expiration timestamp for the refresh token. |
+| RefreshTokenValidationCount | int | Number of times the refresh token has been validated. |
+
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| isAccountLocked | Determines whether the account is currently locked. |
+| unlockAccount | Clears the lockout state and resets counters. |
+| incrementBadLogonAndLock | Increments failed logon counter and locks the account after threshold. |
+| validateRefreshToken | Validates a refresh token against expiration and usage limits. |
+| incrementRefreshTokenValidationCount | Increments the number of refresh token validations. |
+| clearRefreshToken | Clears the refresh token and associated validation state. |
+| setRefreshToken | Sets a new refresh token and resets its validation state. |
+| getRefreshExpiration | Gets the expiration time for the current refresh token. |
+
+## See Also
+- [SQLServerAuthenticator](../SQLServerAuthenticator/index.md)

--- a/MicroM/core/Web/Authentication/SQLServerAuthenticator/AccountLockout.cs
+++ b/MicroM/core/Web/Authentication/SQLServerAuthenticator/AccountLockout.cs
@@ -3,19 +3,44 @@
 namespace MicroM.Web.Authentication
 {
     /// <summary>
-    /// Represents the AccountLockout.
+    /// Tracks failed login attempts, lockout expiration, and refresh token
+    /// validation for a single account.
     /// </summary>
+    /// <remarks>
+    /// Instances of this class are cached by <see cref="SQLServerAuthenticator"/>
+    /// to preserve lockout state between authentication requests.
+    /// </remarks>
     public class AccountLockout
     {
+        /// <summary>
+        /// Number of consecutive failed logon attempts. When this value exceeds
+        /// the threshold, the account is locked for a period of time.
+        /// </summary>
         int _badlogon_attempts = 0;
+
+        /// <summary>
+        /// Point in time when the current lockout expires. A <see langword="null"/>
+        /// value indicates the account is not locked.
+        /// </summary>
         DateTime? _locked_until = null;
 
+        /// <summary>
+        /// Refresh token issued for the account.
+        /// </summary>
         string? _RefreshToken = null;
+
+        /// <summary>
+        /// Expiration time for the current refresh token.
+        /// </summary>
         DateTime? _RefreshTokenExpiration = null;
+
+        /// <summary>
+        /// Number of times the refresh token has been validated.
+        /// </summary>
         int _RefreshTokenValidationCount = 0;
 
         /// <summary>
-        /// Performs the isAccountLocked operation.
+        /// Determines whether the account is currently locked.
         /// </summary>
         public bool isAccountLocked()
         {
@@ -25,7 +50,7 @@ namespace MicroM.Web.Authentication
         }
 
         /// <summary>
-        /// Performs the unlockAccount operation.
+        /// Clears the lockout state and resets the failed logon counter.
         /// </summary>
         public void unlockAccount()
         {
@@ -34,8 +59,13 @@ namespace MicroM.Web.Authentication
         }
 
         /// <summary>
-        /// Performs the incrementBadLogonAndLock operation.
+        /// Increments the failed logon counter and locks the account when the
+        /// configured threshold is exceeded.
         /// </summary>
+        /// <remarks>
+        /// After more than ten consecutive failures the account is locked for
+        /// fifteen minutes.
+        /// </remarks>
         public void incrementBadLogonAndLock()
         {
             _badlogon_attempts++;
@@ -46,7 +76,7 @@ namespace MicroM.Web.Authentication
         }
 
         /// <summary>
-        /// Performs the validateRefreshToken operation.
+        /// Validates a refresh token against expiration and usage limits.
         /// </summary>
         public LoginAttemptStatus validateRefreshToken(string refreshToken, int max_refresh_count)
         {
@@ -73,7 +103,7 @@ namespace MicroM.Web.Authentication
         }
 
         /// <summary>
-        /// Performs the incrementRefreshTokenValidationCount operation.
+        /// Increments the number of refresh token validations.
         /// </summary>
         public void incrementRefreshTokenValidationCount()
         {
@@ -81,7 +111,7 @@ namespace MicroM.Web.Authentication
         }
 
         /// <summary>
-        /// Performs the clearRefreshToken operation.
+        /// Clears the refresh token and associated validation state.
         /// </summary>
         public void clearRefreshToken()
         {
@@ -91,7 +121,7 @@ namespace MicroM.Web.Authentication
         }
 
         /// <summary>
-        /// Performs the setRefreshToken operation.
+        /// Sets a new refresh token and resets its validation state.
         /// </summary>
         public void setRefreshToken(string refreshToken)
         {
@@ -101,7 +131,7 @@ namespace MicroM.Web.Authentication
         }
 
         /// <summary>
-        /// Performs the getRefreshExpiration operation.
+        /// Gets the expiration time for the current refresh token.
         /// </summary>
         public DateTime? getRefreshExpiration() => _RefreshTokenExpiration;
 


### PR DESCRIPTION
## Summary
- expand AccountLockout summary and remarks to explain lockout state tracking and SQLServerAuthenticator usage
- document internal state fields for lockout counters, refresh tokens, and expiration
- add backend docs page detailing AccountLockout properties and methods

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: del not found in build script)*


------
https://chatgpt.com/codex/tasks/task_e_68ab225e5b448324acc11bfbf4e50d85