### PR TITLE
docs: clarify permissions handler and allowed routes

### DIFF
--- a/MicroM/core/Web/Services/SecurityService/PermissionsHandler/AllowedRouteFlags.cs
+++ b/MicroM/core/Web/Services/SecurityService/PermissionsHandler/AllowedRouteFlags.cs
@@ -2,27 +2,29 @@
 {
     /// <summary>
     /// Flags describing which route operations are permitted for an entity.
-    /// These values are combined when building security records to determine
-    /// the routes that a group or user may access.
+    /// The values map to common CRUD operations as well as framework features
+    /// such as lookups, views, procedures and imports. Flags can be combined to
+    /// express the complete set of permissions granted to a user or group and
+    /// are used by the security service when evaluating a request.
     /// </summary>
     [Flags]
     public enum AllowedRouteFlags : ushort
     {
         /// <summary>No route is allowed.</summary>
         None = 0,
-        /// <summary>Allows inserting an entity.</summary>
+        /// <summary>Allows inserting new records into the entity.</summary>
         Insert = 1,
-        /// <summary>Allows updating an entity.</summary>
+        /// <summary>Allows updating existing records.</summary>
         Update = 2,
-        /// <summary>Allows deleting an entity.</summary>
+        /// <summary>Allows deleting records.</summary>
         Delete = 4,
-        /// <summary>Allows retrieving an entity.</summary>
+        /// <summary>Allows retrieving a single record.</summary>
         Get = 8,
-        /// <summary>Allows the default lookup operation.</summary>
+        /// <summary>Allows the default lookup operation for listing data.</summary>
         DefaultLookup = 16,
-        /// <summary>Combination of <see cref="Insert"/>, <see cref="Update"/>, <see cref="Delete"/> and <see cref="Get"/>.</summary>
+        /// <summary>Convenience combination of <see cref="Insert"/>, <see cref="Update"/>, <see cref="Delete"/> and <see cref="Get"/>.</summary>
         Edit = Insert | Update | Delete | Get,
-        /// <summary>Allows custom lookup procedures.</summary>
+        /// <summary>Allows executing custom lookup procedures.</summary>
         CustomLookup = 32,
         /// <summary>Allows access to views.</summary>
         Views = 64,
@@ -30,11 +32,11 @@
         Procs = 128,
         /// <summary>Allows triggering custom actions.</summary>
         Actions = 256,
-        /// <summary>Allows importing data.</summary>
+        /// <summary>Allows importing data for the entity.</summary>
         Import = 512,
-        /// <summary>All flags except <see cref="Import"/>.</summary>
+        /// <summary>Shortcut for all flags except <see cref="Import"/>.</summary>
         All = 511,
-        /// <summary>All flags including <see cref="Import"/>.</summary>
+        /// <summary>Shortcut for all flags including <see cref="Import"/>.</summary>
         AllWithImport = 1023,
     }
 

--- a/MicroM/core/Web/Services/SecurityService/PermissionsHandler/EveryoneAllowedRoutes.cs
+++ b/MicroM/core/Web/Services/SecurityService/PermissionsHandler/EveryoneAllowedRoutes.cs
@@ -11,13 +11,21 @@ namespace MicroM.Web.Services.Security
     /// </summary>
     public enum MicroMEveryoneAllowedRoutes
     {
+        /// <summary>Route used to log the current user out.</summary>
         logoff,
+        /// <summary>Endpoint that refreshes the authentication token.</summary>
         refresh,
+        /// <summary>Checks whether the caller is currently authenticated.</summary>
         isloggedin,
+        /// <summary>Serves static or stored files without authentication.</summary>
         serve,
+        /// <summary>Uploads temporary files that do not require authentication.</summary>
         tmpupload,
+        /// <summary>Starts the password recovery process.</summary>
         recoverpassword,
+        /// <summary>Sends recovery e-mails to users.</summary>
         recoveryemail,
+        /// <summary>Retrieves a thumbnail image for a stored file.</summary>
         thumbnail
     }
 

--- a/MicroM/core/Web/Services/SecurityService/PermissionsHandler/GroupSecurityRecord.cs
+++ b/MicroM/core/Web/Services/SecurityService/PermissionsHandler/GroupSecurityRecord.cs
@@ -29,6 +29,9 @@ namespace MicroM.Web.Services.Security
         /// Replaces the current allowed routes with the provided set.
         /// </summary>
         /// <param name="routes">Route paths that should be allowed for the group.</param>
+        /// <returns>
+        /// <see langword="void"/>. The internal <see cref="AllowedRoutes"/> collection is updated in place.
+        /// </returns>
         public void AddAllowedRoutes(IEnumerable<string> routes)
         {
             AllowedRoutes = routes.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);

--- a/MicroM/core/Web/Services/SecurityService/PermissionsHandler/MicroMPermissionsHandler.cs
+++ b/MicroM/core/Web/Services/SecurityService/PermissionsHandler/MicroMPermissionsHandler.cs
@@ -4,10 +4,12 @@ using Microsoft.AspNetCore.Http;
 namespace MicroM.Web.Services.Security
 {
     /// <summary>
-    /// Authorization handler that validates a request against the
+    /// ASP.NET Core authorization handler that validates a request against the
     /// <see cref="ISecurityService"/>. The handler inspects the current
     /// <see cref="HttpContext"/> to extract route information and delegates
     /// the authorization decision to <see cref="ISecurityService.IsAuthorized"/>.
+    /// It is registered with the authorization middleware and participates in
+    /// the pipeline for every request guarded by <see cref="MicroMPermissionsRequirement"/>.
     /// </summary>
     /// <param name="securityService">Service used to evaluate route permissions.</param>
     /// <param name="http_context_accesor">Accessor for obtaining the current <see cref="HttpContext"/>.</param>

--- a/MicroM/core/Web/Services/SecurityService/PermissionsHandler/MicroMPermissionsRequirement.cs
+++ b/MicroM/core/Web/Services/SecurityService/PermissionsHandler/MicroMPermissionsRequirement.cs
@@ -3,7 +3,7 @@
 namespace MicroM.Web.Services.Security
 {
     /// <summary>
-    /// Constants used by the MicroM authorization system.
+    /// Holds constants for configuring the MicroM permission system.
     /// </summary>
     public class MicroMPermissionsConstants
     {

--- a/MicroM/core/Web/Services/SecurityService/PermissionsHandler/SecurityDefaults.cs
+++ b/MicroM/core/Web/Services/SecurityService/PermissionsHandler/SecurityDefaults.cs
@@ -3,7 +3,9 @@
     /// <summary>
     /// Stores transient cryptographic values used by the framework. These
     /// defaults are generated at runtime and remain valid only for the
-    /// lifetime of the application instance.
+    /// lifetime of the application instance. They provide ephemeral
+    /// encryption material for operations that need temporary protection
+    /// such as token generation during the startup process.
     /// </summary>
     public sealed class SecurityDefaults
     {


### PR DESCRIPTION
## Summary
- expand AllowedRouteFlags description of combined CRUD and custom operations
- document always-allowed routes and group permission records
- clarify security handler middleware and requirement constants

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: del not found in MSBuildTemproot)*

------
https://chatgpt.com/codex/tasks/task_e_68ab227401ec8324b48f3f1627bee4e4