### PR TITLE
docs: add params to CreateEntity overload

### DIFF
--- a/MicroM/core/Web/Services/EntitiesService/EntitiesService.cs
+++ b/MicroM/core/Web/Services/EntitiesService/EntitiesService.cs
@@ -120,6 +120,10 @@ public class EntitiesService : IEntitiesService
     /// <summary>
     /// Creates an entity instance for the specified application.
     /// </summary>
+    /// <param name="entity_name">Name of the entity type to instantiate.</param>
+    /// <param name="server_claims">Claims used to resolve SQL credentials when required.</param>
+    /// <param name="ct">Token to observe for cancellation.</param>
+    /// <returns>The created entity instance, or <see langword="null"/> if the entity type is not found.</returns>
     public EntityBase? CreateEntity(ApplicationOption app, string entity_name, Dictionary<string, object>? server_claims, CancellationToken ct)
     {
         EntityBase? entity = null;

--- a/MicroM/core/Web/Services/EntitiesService/IEntitiesService.cs
+++ b/MicroM/core/Web/Services/EntitiesService/IEntitiesService.cs
@@ -20,6 +20,10 @@ public interface IEntitiesService
     /// <summary>
     /// Creates an entity instance using the provided cancellation token.
     /// </summary>
+    /// <param name="entity_name">Name of the entity type to instantiate.</param>
+    /// <param name="server_claims">Claims used to resolve SQL credentials when required.</param>
+    /// <param name="ct">Token to observe for cancellation.</param>
+    /// <returns>The created entity instance, or <see langword="null"/> if the entity type is not found.</returns>
     EntityBase? CreateEntity(ApplicationOption app, string entity_name, Dictionary<string, object>? server_claims, CancellationToken ct);
 
     /// <summary>


### PR DESCRIPTION
## Summary
- document CreateEntity overload with parameter descriptions and return value
- mirror documentation in IEntitiesService

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: /usr/bin/sh: del: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2f467f888324a9313d85e5a67e00