### PR TITLE
docs: document CreateEntity parameters

### DIFF
--- a/MicroM/core/Web/Services/EntitiesService/EntitiesService.cs
+++ b/MicroM/core/Web/Services/EntitiesService/EntitiesService.cs
@@ -104,8 +104,8 @@ public class EntitiesService : IEntitiesService
     /// <summary>
     /// Creates an Entity if it exists in the configured assembly.
     /// </summary>
-    /// <param name="entity_name"></param>
-    /// <param name="ec"></param>
+    /// <param name="entity_name">Target entity identifier.</param>
+    /// <param name="ec">Optional entity client.</param>
     /// <returns></returns>
     public EntityBase? CreateEntity(ApplicationOption app, string entity_name, Dictionary<string, object>? server_claims, IEntityClient? ec = null)
     {

--- a/MicroM/core/Web/Services/EntitiesService/IEntitiesService.cs
+++ b/MicroM/core/Web/Services/EntitiesService/IEntitiesService.cs
@@ -13,8 +13,8 @@ public interface IEntitiesService
     /// <summary>
     /// Creates an Entity if it exists in the configured assembly.
     /// </summary>
-    /// <param name="entity_name"></param>
-    /// <param name="ec"></param>
+    /// <param name="entity_name">Target entity identifier.</param>
+    /// <param name="ec">Optional entity client.</param>
     /// <returns></returns>
     public EntityBase? CreateEntity(ApplicationOption app, string entity_name, Dictionary<string, object>? server_claims, IEntityClient? ec = null);
     /// <summary>


### PR DESCRIPTION
## Summary
- document target entity identifier and optional entity client parameters on CreateEntity overload

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: SQL Server connection string not valid)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2f479a94832485ba719837ad7a1c