### PR TITLE
docs: add comments for category lookups and entities

### DIFF
--- a/MicroM/core/Generators/ReactGenerator/CategoriesExtensions.cs
+++ b/MicroM/core/Generators/ReactGenerator/CategoriesExtensions.cs
@@ -8,8 +8,19 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.ReactGenerator
 {
+    /// <summary>
+    /// Extension methods used to generate lookup definitions and category
+    /// entity scaffolding for the React code generator.
+    /// </summary>
     public static class CategoriesExtensions
     {
+        /// <summary>
+        /// Appends the lookup definition for the related category of the given
+        /// column to the provided <see cref="StringBuilder"/>.
+        /// </summary>
+        /// <param name="sb">Builder that collects lookup definition content.</param>
+        /// <param name="col">Column containing the related category identifier.</param>
+        /// <param name="indent">Indentation used when formatting the output.</param>
         private static void AppendLookupDefinitionContentCategories(this StringBuilder sb, ColumnBase col, string indent = $"{TAB}")
         {
             var lookup_name = col.RelatedCategoryID;
@@ -20,6 +31,13 @@ namespace MicroM.Generators.ReactGenerator
             sb.Append(CultureInfo.InvariantCulture, $"\n{indent}{TAB}}}");
         }
 
+        /// <summary>
+        /// Generates lookup definition content for all columns that reference a
+        /// category.
+        /// </summary>
+        /// <param name="cols">Collection of columns to inspect.</param>
+        /// <param name="indent">Indentation used when formatting the output.</param>
+        /// <returns>Lookup definition content for all related categories.</returns>
         public static string AsLookupDefinitionContentCategories(this IReadonlyOrderedDictionary<ColumnBase> cols, string indent = $"{TAB}")
         {
             var cols_enumerator = cols.Values.Where(column => string.IsNullOrEmpty(column.RelatedCategoryID) == false).GetEnumerator();
@@ -40,6 +58,12 @@ namespace MicroM.Generators.ReactGenerator
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Builds a comma-separated list of category entity imports for use in
+        /// generated React code.
+        /// </summary>
+        /// <param name="cols">Collection of columns to inspect.</param>
+        /// <returns>Comma-separated list of category entity class names.</returns>
         public static string AsEmbeddedCategoriesImport(this IReadonlyOrderedDictionary<ColumnBase> cols)
         {
             var relatedCategories = string.Join(", ",
@@ -49,6 +73,13 @@ namespace MicroM.Generators.ReactGenerator
             return relatedCategories;
         }
 
+        /// <summary>
+        /// Resolves the human-readable title for the specified category
+        /// identifier by instantiating its definition type.
+        /// </summary>
+        /// <param name="categories_types">Dictionary mapping category identifiers to their definition types.</param>
+        /// <param name="category_id">Identifier of the category to resolve.</param>
+        /// <returns>The category description or an empty string if not found.</returns>
         private static string GetCategoryTitle(this Dictionary<string, Type> categories_types, string category_id)
         {
             string cat_title = "";
@@ -60,6 +91,12 @@ namespace MicroM.Generators.ReactGenerator
             return cat_title;
         }
 
+        /// <summary>
+        /// Generates a single category entity using the template system.
+        /// </summary>
+        /// <param name="categories_types">Dictionary mapping category identifiers to their definition types.</param>
+        /// <param name="category_id">Identifier of the category to generate.</param>
+        /// <returns>Generated category entity code.</returns>
         private static string AppendCategoryEntity(this Dictionary<string, Type> categories_types, string category_id)
         {
             string title = categories_types.GetCategoryTitle(category_id);
@@ -72,6 +109,13 @@ namespace MicroM.Generators.ReactGenerator
             return Templates.CATEGORY_ENTITY_TEMPLATE.ReplaceTemplate(parms);
         }
 
+        /// <summary>
+        /// Generates entity class definitions for all categories referenced by
+        /// the provided columns.
+        /// </summary>
+        /// <param name="cols">Collection of columns to inspect.</param>
+        /// <param name="categories_types">Dictionary mapping category identifiers to their definition types.</param>
+        /// <returns>Formatted string with generated category entities.</returns>
         public static string AsCategoriesEntities(this IReadonlyOrderedDictionary<ColumnBase> cols, Dictionary<string, Type> categories_types)
         {
             var cols_enumerator = cols.Values.Where(column => string.IsNullOrEmpty(column.RelatedCategoryID) == false).GetEnumerator();


### PR DESCRIPTION
## Summary
- document React generator category extensions
- cover lookup definition helpers and entity generation methods

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: /usr/bin/sh: 2: /tmp/MSBuildTemproot/tmp76369c19d4c54363b42d22cf2331b3ef.exec.cmd: del: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab368437888324a20f1d1501eba37a