### PR TITLE
Document DropExtensions SQL generator methods

### DIFF
--- a/MicroM/core/Generators/SQLGenerator/DropExtensions.cs
+++ b/MicroM/core/Generators/SQLGenerator/DropExtensions.cs
@@ -6,8 +6,19 @@ using static MicroM.Generators.Constants;
 
 namespace MicroM.Generators.SQLGenerator
 {
+    /// <summary>
+    /// Extension methods that generate SQL scripts for drop stored procedures.
+    /// </summary>
     internal static class DropExtensions
     {
+        /// <summary>
+        /// Builds scripts for an internal drop procedure and its caller for the specified entity.
+        /// </summary>
+        /// <typeparam name="T">Type of entity to drop.</typeparam>
+        /// <param name="entity">Entity definition used to generate the scripts.</param>
+        /// <param name="create_or_alter">Whether to emit a CREATE or CREATE OR ALTER statement.</param>
+        /// <param name="force_fake">Generate scripts even for entities marked as fake.</param>
+        /// <returns>SQL scripts for the internal drop procedure and wrapper.</returns>
         internal static List<string> AsCreateIDropProc<T>(this T entity, bool create_or_alter = false, bool force_fake = false) where T : EntityBase
         {
             List<string> scripts = [];
@@ -29,6 +40,14 @@ namespace MicroM.Generators.SQLGenerator
             return scripts;
         }
 
+        /// <summary>
+        /// Builds scripts for a standard drop procedure for the specified entity.
+        /// </summary>
+        /// <typeparam name="T">Type of entity to drop.</typeparam>
+        /// <param name="entity">Entity definition used to generate the scripts.</param>
+        /// <param name="create_or_alter">Whether to emit a CREATE or CREATE OR ALTER statement.</param>
+        /// <param name="force_fake">Generate scripts even for entities marked as fake.</param>
+        /// <returns>SQL scripts for the drop procedure.</returns>
         internal static List<string> AsCreateNormalDropProc<T>(this T entity, bool create_or_alter = false, bool force_fake = false) where T : EntityBase
         {
             List<string> scripts = [];
@@ -50,6 +69,15 @@ namespace MicroM.Generators.SQLGenerator
             return scripts;
         }
 
+        /// <summary>
+        /// Builds drop procedure scripts, optionally generating the internal drop variant.
+        /// </summary>
+        /// <typeparam name="T">Type of entity to drop.</typeparam>
+        /// <param name="entity">Entity definition used to generate the scripts.</param>
+        /// <param name="create_or_alter">Whether to emit a CREATE or CREATE OR ALTER statement.</param>
+        /// <param name="with_idrop">Generate internal drop scripts if set to <c>true</c>.</param>
+        /// <param name="force_fake">Generate scripts even for entities marked as fake.</param>
+        /// <returns>SQL scripts for the drop procedure.</returns>
         public static List<string> AsCreateDropProc<T>(this T entity, bool create_or_alter = false, bool with_idrop = false, bool force_fake = false) where T : EntityBase
         {
             if (with_idrop)


### PR DESCRIPTION
## Summary
- add summary for DropExtensions
- document IDrop and Drop SQL generator helpers

## Testing
- `dotnet test MicroM.sln` *(fails: del: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3579881c8324bb1c86235d74efed