### PR TITLE
docs: document generators regex

### DIFF
--- a/MicroM/core/Generators/GeneratorsRegex.cs
+++ b/MicroM/core/Generators/GeneratorsRegex.cs
@@ -2,11 +2,22 @@
 
 namespace MicroM.Generators
 {
+    /// <summary>
+    /// Provides commonly used regular expressions for code generation tasks.
+    /// </summary>
     public partial class GeneratorsRegex
     {
+        /// <summary>
+        /// Matches occurrences of multiple consecutive empty lines.
+        /// </summary>
+        /// <returns>A <see cref="Regex"/> that identifies multiple empty lines.</returns>
         [GeneratedRegex(@"[ \t]*\r?\n(\s*\r?\n)+", RegexOptions.Multiline)]
         public static partial Regex MultipleEmptyLines();
 
+        /// <summary>
+        /// Splits camel case formatted strings into individual words.
+        /// </summary>
+        /// <returns>A <see cref="Regex"/> used to locate camel case word boundaries.</returns>
         [GeneratedRegex(@"(?<!^)(?=[A-Z])")]
         public static partial Regex SplitCamelCaseWords();
     }


### PR DESCRIPTION
## Summary
- add class documentation for `GeneratorsRegex`
- document `MultipleEmptyLines` and `SplitCamelCaseWords`

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: /usr/bin/sh: 2: ...: del: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3575d0648324a76b1d342bcbe3d9