### PR TITLE
docs: describe string helpers in CommonExtensions

### DIFF
--- a/MicroM/core/Generators/Extensions/CommonExtensions.cs
+++ b/MicroM/core/Generators/Extensions/CommonExtensions.cs
@@ -1,5 +1,9 @@
 ﻿namespace MicroM.Generators.Extensions
 {
+    /// <summary>
+    /// String utility helper extensions for tasks such as removing empty lines and
+    /// splitting camel case words.
+    /// </summary>
     public static class CommonExtensions
     {
         private static readonly string MULTIPLE_LINE_REPLACEMENT = Environment.NewLine + Environment.NewLine;


### PR DESCRIPTION
## Summary
- clarify string utility helpers in `CommonExtensions`

## Testing
- `dotnet test MicroM/MicroM.sln` *(fails: del not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab35746628832489fc1c71a388ba12