### PR TITLE
Add XML documentation for token container base

### DIFF
--- a/MicroM/core/Generators/TemplateValuesBase.cs
+++ b/MicroM/core/Generators/TemplateValuesBase.cs
@@ -4,16 +4,25 @@ using System.Runtime.CompilerServices;
 
 namespace MicroM.Generators
 {
+    /// <summary>
+    /// Provides a base container for storing template tokens.
+    /// </summary>
     internal abstract class TemplateValuesBase
     {
         public readonly Dictionary<string, string> tokens = [];
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemplateValuesBase"/> class and fills the token dictionary.
+        /// </summary>
         public TemplateValuesBase()
         {
             FillTokens();
         }
 
         // MMC: this aims to ease the use of the tokens dictionary
+        /// <summary>
+        /// Populates the token dictionary with placeholders for init-only string properties.
+        /// </summary>
         private void FillTokens()
         {
             object obj = this;


### PR DESCRIPTION
## Summary
- Document TemplateValuesBase class as token container
- Add summaries for constructor and FillTokens method

## Testing
- ⚠️ `dotnet test MicroM/MicroM.sln` (failed: `/usr/bin/sh: 2: /tmp/MSBuildTemproot/...del: not found`)


------
https://chatgpt.com/codex/tasks/task_e_68ab3571f2f08324aa11b3189ca3f1e1