### PR TITLE
Document DataDictionary classes

### DIFF
--- a/MicroM/Documentation-Progress/Backend/docs-state-backend.md
+++ b/MicroM/Documentation-Progress/Backend/docs-state-backend.md
@@ -19,8 +19,8 @@ This file tracks the current documentation state of the backend (`/MicroM/core`)
 - Notes: Namespace and all public types documented with XML comments and pages.
 
 ### MicroM.DataDictionary
-- State: Incomplete ⚠️
-- Notes: Added documentation for ApplicationsUrls, FileStore, FileStoreProcess, FileStoreStatus and Numbering; other entities remain pending.
+- State: Complete ✅
+- Notes: Namespace and all public types documented with XML comments and pages.
 
 ### MicroM.DataDictionary.CategoriesDefinitions
 - State: Complete ✅

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/ConfigurationDB/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/ConfigurationDB/index.md
@@ -1,0 +1,22 @@
+﻿# Class: MicroM.DataDictionary.ConfigurationDB
+## Overview
+Entity used to manage configuration database settings.
+
+**Inheritance**
+Entity<ConfigurationDBDef> -> ConfigurationDB
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ConfigurationDB() | Default constructor. |
+| ConfigurationDB(IEntityClient, IMicroMEncryption?) | Creates a ConfigurationDB entity with the specified client and encryptor. |
+
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| GetData(CancellationToken, MicroMOptions?, Dictionary<string, object>?, IWebAPIServices?, string?) | Retrieves configuration data. |
+| UpdateData(CancellationToken, bool, MicroMOptions?, Dictionary<string, object>?, IWebAPIServices?, string?) | Updates configuration data. |
+
+## See Also
+- [ConfigurationDBDef](../ConfigurationDBDef/index.md)
+- [ConfigurationDBHandlers](../ConfigurationDBHandlers/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/ConfigurationDBDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/ConfigurationDBDef/index.md
@@ -1,0 +1,37 @@
+﻿# Class: MicroM.DataDictionary.ConfigurationDBDef
+## Overview
+Schema definition for configuration database settings.
+
+**Inheritance**
+EntityDefinition -> ConfigurationDBDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ConfigurationDBDef() | Initializes a new instance. |
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| c_confgidb_id | Column<string> | Primary identifier for the configuration record. |
+| vc_configsqlserver | Column<string> | SQL server hosting the configuration database. |
+| vc_configsqluser | Column<string> | SQL login used for configuration operations. |
+| vc_configsqlpassword | Column<string?> | Password for the configuration SQL login. |
+| vc_configdatabase | Column<string> | Name of the configuration database. |
+| vc_certificatethumbprint | Column<string> | Thumbprint of the certificate used for encryption. |
+| vc_certificatepassword | Column<string> | Password protecting the certificate key. |
+| vc_certificatename | Column<string> | Display name of the certificate. |
+| b_adminuserhasrights | Column<bool> | Indicates administrator rights. |
+| b_configdbexists | Column<bool> | Indicates if the configuration database exists. |
+| b_configuserexists | Column<bool> | Indicates if the configuration user exists. |
+| b_secretsconfigured | Column<bool> | Indicates if secrets have been configured. |
+| b_defaultcertificate | Column<bool> | Indicates if the default certificate was used. |
+| b_thumbprintconfigured | Column<bool> | Indicates if a certificate thumbprint is configured. |
+| b_thumbprintfound | Column<bool> | Indicates if the configured thumbprint was found. |
+| b_certificatefound | Column<bool> | Indicates if a certificate was found. |
+| b_secretsfilevalid | Column<bool> | Indicates if the secrets file is valid. |
+| b_recreatedatabase | Column<bool> | Indicates whether the database should be recreated. |
+| dfg_brwStandard | ViewDefinition | Default browse view definition. |
+
+## See Also
+- [ConfigurationDB](../ConfigurationDB/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/ConfigurationDBHandlers/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/ConfigurationDBHandlers/index.md
@@ -1,0 +1,13 @@
+﻿# Class: MicroM.DataDictionary.ConfigurationDBHandlers
+## Overview
+Helper methods for managing configuration database settings and secrets.
+
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| ReadConfigurationDBParms(string, CancellationToken) | Reads configuration database parameters from the encrypted secrets file. |
+| HandleGetData(ConfigurationDB, MicroMOptions, Dictionary<string, object>, CancellationToken) | Retrieves configuration database settings and status information. |
+| HandleUpdateData(ConfigurationDB, bool, MicroMOptions, Dictionary<string, object>, IWebAPIServices?, CancellationToken) | Updates configuration database settings and creates the database if required. |
+
+## See Also
+- [ConfigurationDB](../ConfigurationDB/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/MicromUsers/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/MicromUsers/index.md
@@ -1,0 +1,30 @@
+﻿# Class: MicroM.DataDictionary.MicromUsers
+## Overview
+Entity for interacting with MicroM user records.
+
+**Inheritance**
+Entity<MicromUsersDef> -> MicromUsers
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| MicromUsers() | Default constructor. |
+| MicromUsers(IEntityClient, IMicroMEncryption?) | Creates a MicromUsers entity with the specified client and encryptor. |
+
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| InsertData(CancellationToken, bool, MicroMOptions?, Dictionary<string, object>?, IWebAPIServices?, string?) | Inserts the user data hashing the password before saving. |
+| Logoff(string, IEntityClient, CancellationToken) | Logs off the specified user. |
+| GetUserData(string?, string?, string, IEntityClient, CancellationToken) | Retrieves user data for the given identifiers. |
+| GetClaims(string, IEntityClient, CancellationToken) | Retrieves both server and client claims for a user. |
+| UpdateLoginAttempt(string, string, string?, bool, int, int, int, string, string, IEntityClient, CancellationToken) | Updates login attempt information and returns the result. |
+| RefreshToken(string, string, string, string, int, int, IEntityClient, CancellationToken) | Refreshes a user\'s token and returns the new token information. |
+| GetRecoveryCode(string, IEntityClient, CancellationToken) | Obtains a recovery code for the specified user. |
+| GetRecoveryEmails(string, IEntityClient, CancellationToken) | Retrieves recovery email addresses for the user. |
+| RecoverPassword(string, string, string, IEntityClient, CancellationToken) | Recovers a user\'s password using a recovery code. |
+| usr_setPassword(string, string, IEntityClient, CancellationToken) | Sets a new password hash for the user. |
+| usr_resetPassword(string, IEntityClient, CancellationToken) | Resets a user\'s password to a random value. |
+
+## See Also
+- [MicromUsersDef](../MicromUsersDef/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/MicromUsersDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/MicromUsersDef/index.md
@@ -1,0 +1,49 @@
+﻿# Class: MicroM.DataDictionary.MicromUsersDef
+## Overview
+Schema definition for MicroM user records.
+
+**Inheritance**
+EntityDefinition -> MicromUsersDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| MicromUsersDef() | Initializes a new instance. |
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| c_user_id | Column<string> | Primary identifier of the user. |
+| vc_username | Column<string> | Username used for authentication. |
+| vc_email | Column<string?> | User email address. |
+| vc_pwhash | Column<string> | Password hash value. |
+| vb_sid | Column<string?> | Security identifier. |
+| i_badlogonattempts | Column<int> | Failed login attempt count. |
+| bt_disabled | Column<bool> | Indicates whether the user is disabled. |
+| dt_locked | Column<DateTime?> | Lockout expiration time. |
+| dt_last_login | Column<DateTime?> | Timestamp of the last successful login. |
+| dt_last_refresh | Column<DateTime?> | Timestamp of the last refresh token. |
+| vc_recovery_code | Column<string?> | Recovery code for password reset. |
+| dt_last_recovery | Column<DateTime?> | Time when recovery code was last generated. |
+| c_usertype_id | Column<string> | User type identifier. |
+| vc_user_groups | Column<string[]?> | User group memberships. |
+| bt_islocked | Column<bool> | Indicates whether the user is locked. |
+| i_locked_minutes_remaining | Column<int> | Minutes remaining until unlock. |
+| vc_password | Column<string> | Plain text password used during creation. |
+| usr_brwStandard | ViewDefinition | Default browse view definition. |
+| usr_getUserData | ProcedureDefinition | Procedure to get user data. |
+| usr_updateLoginAttempt | ProcedureDefinition | Procedure to update login attempt data. |
+| usr_logoff | ProcedureDefinition | Procedure to log off a user. |
+| usr_setPassword | ProcedureDefinition | Procedure to set a user password. |
+| usr_resetPassword | ProcedureDefinition | Procedure to reset a user password. |
+| usr_GetClientClaims | ProcedureDefinition | Procedure to retrieve client claims. |
+| usr_GetServerClaims | ProcedureDefinition | Procedure to retrieve server claims. |
+| usr_GetEnabledMenus | ProcedureDefinition | Procedure to retrieve enabled menus. |
+| usr_GetRecoveryCode | ProcedureDefinition | Procedure to generate a recovery code. |
+| usr_GetRecoveryEmails | ProcedureDefinition | Procedure to get recovery email addresses. |
+| usr_RecoverPassword | ProcedureDefinition | Procedure to recover a password. |
+| UNUsername | EntityUniqueConstraint | Unique constraint ensuring usernames are unique. |
+| FKGroups | EntityForeignKey<MicromUsersGroups, MicromUsers> | Relationship to the groups associated with the user. |
+
+## See Also
+- [MicromUsers](../MicromUsers/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/MicromUsersDevices/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/MicromUsersDevices/index.md
@@ -1,0 +1,15 @@
+﻿# Class: MicroM.DataDictionary.MicromUsersDevices
+## Overview
+Entity for managing device records linked to users.
+
+**Inheritance**
+Entity<MicromUsersDevicesDef> -> MicromUsersDevices
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| MicromUsersDevices() | Default constructor. |
+| MicromUsersDevices(IEntityClient, IMicroMEncryption?) | Creates a MicromUsersDevices entity with the specified client and encryptor. |
+
+## See Also
+- [MicromUsersDevicesDef](../MicromUsersDevicesDef/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/MicromUsersDevicesDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/MicromUsersDevicesDef/index.md
@@ -1,0 +1,28 @@
+﻿# Class: MicroM.DataDictionary.MicromUsersDevicesDef
+## Overview
+Schema definition for devices associated with MicroM users.
+
+**Inheritance**
+EntityDefinition -> MicromUsersDevicesDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| MicromUsersDevicesDef() | Initializes a new instance. |
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| c_user_id | Column<string> | User identifier. |
+| c_device_id | Column<string> | Device identifier. |
+| vc_useragent | Column<string?> | User agent string reported by the device. |
+| vc_ipaddress | Column<string?> | IP address of the device. |
+| vc_refreshtoken | Column<string?> | Refresh token assigned to the device. |
+| dt_refresh_expiration | Column<DateTime?> | Expiration time of the refresh token. |
+| i_refreshcount | Column<int> | Number of times the token has been refreshed. |
+| usd_brwStandard | ViewDefinition | Default browse view definition. |
+| FKMicromUsers | EntityForeignKey<MicromUsers, MicromUsersDevices> | Relationship to the owning user. |
+| usd_refreshToken | ProcedureDefinition | Procedure to refresh a device token. |
+
+## See Also
+- [MicromUsersDevices](../MicromUsersDevices/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/ViewParms/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/ViewParms/index.md
@@ -1,0 +1,15 @@
+﻿# Class: MicroM.DataDictionary.ViewParms
+## Overview
+Entity for view parameter records.
+
+**Inheritance**
+Entity<ViewParmsDef> -> ViewParms
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ViewParms() | Default constructor. |
+| ViewParms(IEntityClient, IMicroMEncryption?) | Creates entity using the specified client and encryptor. |
+
+## See Also
+- [ViewParmsDef](../ViewParmsDef/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/ViewParmsDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/ViewParmsDef/index.md
@@ -1,0 +1,29 @@
+﻿# Class: MicroM.DataDictionary.ViewParmsDef
+## Overview
+Schema definition for view parameters.
+
+**Inheritance**
+EntityDefinition -> ViewParmsDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ViewParmsDef() | Initializes a new instance. |
+
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| c_object_id | Column<string> | Identifier of the object that owns the view. |
+| c_proc_id | Column<int> | Identifier of the procedure. |
+| c_viewparm_id | Column<int> | Primary key for the view parameter. |
+| vc_parmname | Column<string> | Name of the parameter. |
+| i_columnmapping | Column<int?> | Column mapping identifier. |
+| vc_compoundgroup | Column<string?> | Compound group name. |
+| i_compoundposition | Column<int?> | Position within the compound group. |
+| bt_compoundkey | Column<bool> | Indicates membership in a compound key. |
+| bt_browsingkey | Column<bool> | Indicates use as a browsing key. |
+| vip_brwStandard | ViewDefinition | Default browse view for parameters. |
+| FKObjects | EntityForeignKey<Procs, ViewParms> | Relationship to procedure entity. |
+
+## See Also
+- [ViewParms](../ViewParms/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary/index.md
@@ -17,6 +17,9 @@ Data dictionary entity definitions and related helpers.
 | [Categories](Categories/index.md) | Entity for working with categories. |
 | [CategoriesValuesDef](CategoriesValuesDef/index.md) | Schema definition for category values. |
 | [CategoriesValues](CategoriesValues/index.md) | Entity for working with category values. |
+| [ConfigurationDBDef](ConfigurationDBDef/index.md) | Schema definition for configuration database settings. |
+| [ConfigurationDB](ConfigurationDB/index.md) | Entity used to manage configuration database settings. |
+| [ConfigurationDBHandlers](ConfigurationDBHandlers/index.md) | Helper methods for configuration database operations. |
 | [FileStoreDef](FileStoreDef/index.md) | Schema definition for stored files. |
 | [FileStore](FileStore/index.md) | Entity for stored files. |
 | [FileStoreProcessDef](FileStoreProcessDef/index.md) | Schema definition for file storage processes. |
@@ -25,8 +28,14 @@ Data dictionary entity definitions and related helpers.
 | [FileStoreStatus](FileStoreStatus/index.md) | Entity for file status records. |
 | [MicromMenusDef](MicromMenusDef/index.md) | Schema definition for MicroM menus. |
 | [MicromMenus](MicromMenus/index.md) | Entity for working with MicroM menus. |
+| [MicromUsersDef](MicromUsersDef/index.md) | Schema definition for MicroM user records. |
+| [MicromUsers](MicromUsers/index.md) | Entity for interacting with MicroM user records. |
+| [MicromUsersDevicesDef](MicromUsersDevicesDef/index.md) | Schema definition for user device records. |
+| [MicromUsersDevices](MicromUsersDevices/index.md) | Entity for managing device records linked to users. |
 | [NumberingDef](NumberingDef/index.md) | Schema definition for sequential numbers. |
 | [Numbering](Numbering/index.md) | Entity for sequential number operations. |
+| [ViewParmsDef](ViewParmsDef/index.md) | Schema definition for view parameters. |
+| [ViewParms](ViewParms/index.md) | Entity for view parameter records. |
 
 ## Enums
 | Enum | Description |
@@ -44,5 +53,5 @@ Data dictionary entity definitions and related helpers.
 | - | - |
 
 ## Remarks
-Several additional entities remain undocumented.
+None.
 

--- a/MicroM/core/DataDictionary/Entities/ConfigurationDB/ConfigurationDB.cs
+++ b/MicroM/core/DataDictionary/Entities/ConfigurationDB/ConfigurationDB.cs
@@ -8,43 +8,135 @@ using static System.ArgumentNullException;
 
 namespace MicroM.DataDictionary;
 
+/// <summary>
+/// Definition of configuration database parameters stored for server setup.
+/// </summary>
 public class ConfigurationDBDef : EntityDefinition
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationDBDef"/> class.
+    /// </summary>
     public ConfigurationDBDef() : base("dfg", nameof(ConfigurationDB)) { Fake = true; }
 
+    /// <summary>
+    /// Primary identifier for the configuration record.
+    /// </summary>
     public readonly Column<string> c_confgidb_id = Column<string>.PK(value: "1");
 
+    /// <summary>
+    /// SQL server hosting the configuration database.
+    /// </summary>
     public readonly Column<string> vc_configsqlserver = new(sql_type: SqlDbType.VarChar, size: 255);
+
+    /// <summary>
+    /// SQL login used for configuration operations.
+    /// </summary>
     public readonly Column<string> vc_configsqluser = new(sql_type: SqlDbType.VarChar, size: 255);
+
+    /// <summary>
+    /// Password for the configuration SQL login.
+    /// </summary>
     public readonly Column<string?> vc_configsqlpassword = new(sql_type: SqlDbType.VarChar, size: 2048, nullable: true);
+
+    /// <summary>
+    /// Name of the configuration database.
+    /// </summary>
     public readonly Column<string> vc_configdatabase = new(sql_type: SqlDbType.VarChar, size: 255);
 
+    /// <summary>
+    /// Thumbprint of the certificate used for encryption.
+    /// </summary>
     public readonly Column<string> vc_certificatethumbprint = new(sql_type: SqlDbType.VarChar, size: 255);
+
+    /// <summary>
+    /// Password protecting the certificate's private key.
+    /// </summary>
     public readonly Column<string> vc_certificatepassword = new(sql_type: SqlDbType.VarChar, size: 2048);
+
+    /// <summary>
+    /// Display name of the certificate.
+    /// </summary>
     public readonly Column<string> vc_certificatename = new(sql_type: SqlDbType.VarChar, size: 2048);
 
+    /// <summary>
+    /// Indicates whether the administrator has required rights.
+    /// </summary>
     public readonly Column<bool> b_adminuserhasrights = new(sql_type: SqlDbType.Bit);
+
+    /// <summary>
+    /// Flag indicating if the configuration database exists.
+    /// </summary>
     public readonly Column<bool> b_configdbexists = new(sql_type: SqlDbType.Bit);
+
+    /// <summary>
+    /// Flag indicating if the configuration user exists.
+    /// </summary>
     public readonly Column<bool> b_configuserexists = new(sql_type: SqlDbType.Bit);
+
+    /// <summary>
+    /// Flag indicating if secrets have been configured.
+    /// </summary>
     public readonly Column<bool> b_secretsconfigured = new(sql_type: SqlDbType.Bit);
+
+    /// <summary>
+    /// Flag indicating if the default certificate was used.
+    /// </summary>
     public readonly Column<bool> b_defaultcertificate = new(sql_type: SqlDbType.Bit);
+
+    /// <summary>
+    /// Flag indicating if a certificate thumbprint is configured.
+    /// </summary>
     public readonly Column<bool> b_thumbprintconfigured = new(sql_type: SqlDbType.Bit);
+
+    /// <summary>
+    /// Flag indicating if the configured thumbprint was found.
+    /// </summary>
     public readonly Column<bool> b_thumbprintfound = new(sql_type: SqlDbType.Bit);
+
+    /// <summary>
+    /// Flag indicating if a certificate was found.
+    /// </summary>
     public readonly Column<bool> b_certificatefound = new(sql_type: SqlDbType.Bit);
+
+    /// <summary>
+    /// Flag indicating if the secrets file is valid.
+    /// </summary>
     public readonly Column<bool> b_secretsfilevalid = new(sql_type: SqlDbType.Bit);
 
+    /// <summary>
+    /// Indicates whether the database should be recreated.
+    /// </summary>
     public readonly Column<bool> b_recreatedatabase = new(sql_type: SqlDbType.Bit);
 
+    /// <summary>
+    /// Default browse view definition.
+    /// </summary>
     public ViewDefinition dfg_brwStandard { get; private set; } = new(nameof(c_confgidb_id));
 
 }
 
+/// <summary>
+/// Entity used to manage configuration database settings.
+/// </summary>
 public class ConfigurationDB : Entity<ConfigurationDBDef>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationDB"/> class.
+    /// </summary>
     public ConfigurationDB() : base() { }
+
+    /// <summary>
+    /// Initializes a new instance with a database client and optional encryptor.
+    /// </summary>
+    /// <param name="ec">Database client.</param>
+    /// <param name="encryptor">Optional encryptor.</param>
     public ConfigurationDB(IEntityClient ec, IMicroMEncryption? encryptor = null) : base(ec, encryptor) { }
 
 
+    /// <summary>
+    /// Retrieves configuration data.
+    /// </summary>
+    /// <inheritdoc/>
     public override async Task<bool> GetData(CancellationToken ct, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null)
     {
         ThrowIfNull(server_claims);
@@ -52,6 +144,10 @@ public class ConfigurationDB : Entity<ConfigurationDBDef>
         return await HandleGetData(this, options, server_claims, ct);
     }
 
+    /// <summary>
+    /// Updates configuration data.
+    /// </summary>
+    /// <inheritdoc/>
     public override async Task<DBStatusResult> UpdateData(CancellationToken ct, bool throw_dbstat_exception = false, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null)
     {
         ThrowIfNull(server_claims);

--- a/MicroM/core/DataDictionary/Entities/ConfigurationDB/ConfigurationDBHandlers.cs
+++ b/MicroM/core/DataDictionary/Entities/ConfigurationDB/ConfigurationDBHandlers.cs
@@ -13,8 +13,11 @@ using static MicroM.Validators.Expressions;
 
 namespace MicroM.DataDictionary;
 
+/// <summary>
+/// Helper methods for managing configuration database settings and secrets.
+/// </summary>
 public static class ConfigurationDBHandlers
-{
+{    
 
     private async static Task<InitialConfigurationResult> CheckInitialStatus(IEntityClient dbc, string config_user, string configuration_db, CancellationToken ct)
     {
@@ -48,6 +51,12 @@ public static class ConfigurationDBHandlers
         await File.WriteAllTextAsync(config_file, encrypted, ct);
     }
 
+    /// <summary>
+    /// Reads configuration database parameters from the encrypted secrets file.
+    /// </summary>
+    /// <param name="certificate_thumbprint">Thumbprint of the certificate used to decrypt the file.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Decrypted configuration options if available.</returns>
     public async static Task<SecretsOptions?> ReadConfigurationDBParms(string certificate_thumbprint, CancellationToken ct)
     {
         SecretsOptions? result = null;
@@ -66,6 +75,14 @@ public static class ConfigurationDBHandlers
         return result;
     }
 
+    /// <summary>
+    /// Retrieves configuration database settings and status information.
+    /// </summary>
+    /// <param name="cfg">Configuration database entity to populate.</param>
+    /// <param name="options">Application options.</param>
+    /// <param name="server_claims">Claims for the current server user.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns><c>true</c> if the operation succeeds.</returns>
     public async static Task<bool> HandleGetData(ConfigurationDB cfg, MicroMOptions options, Dictionary<string, object> server_claims, CancellationToken ct)
     {
         // MMC: this is the logged in user to the control panel
@@ -143,6 +160,16 @@ public static class ConfigurationDBHandlers
 
     }
 
+    /// <summary>
+    /// Updates configuration database settings and creates the database if required.
+    /// </summary>
+    /// <param name="cfg">Configuration database entity containing updated values.</param>
+    /// <param name="throw_dbstat_exception">Indicates whether to throw on database status failure.</param>
+    /// <param name="options">Application options.</param>
+    /// <param name="server_claims">Claims for the current server user.</param>
+    /// <param name="api">Optional API services for refresh operations.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Status of the update operation.</returns>
     public async static Task<DBStatusResult> HandleUpdateData(ConfigurationDB cfg, bool throw_dbstat_exception, MicroMOptions options, Dictionary<string, object> server_claims, IWebAPIServices? api, CancellationToken ct)
     {
         // MMC: this is the logged in user to the control panel

--- a/MicroM/core/DataDictionary/Entities/MicromUsers/MicromUsers.cs
+++ b/MicroM/core/DataDictionary/Entities/MicromUsers/MicromUsers.cs
@@ -11,50 +11,84 @@ using System.Data;
 
 namespace MicroM.DataDictionary;
 
-
+/// <summary>
+/// Schema definition for MicroM user records.
+/// </summary>
 public class MicromUsersDef : EntityDefinition
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MicromUsersDef"/> class.
+    /// </summary>
     public MicromUsersDef() : base("usr", nameof(MicromUsers)) { SQLCreationOptions = SQLCreationOptionsMetadata.WithIUpdateAndIDrop; }
 
+    /// <summary>Primary identifier of the user.</summary>
     public readonly Column<string> c_user_id = Column<string>.PK(autonum: true);
+    /// <summary>Username used for authentication.</summary>
     public readonly Column<string> vc_username = Column<string>.Text();
+    /// <summary>User email address.</summary>
     public readonly Column<string?> vc_email = Column<string?>.Text(nullable: true);
+    /// <summary>Password hash value.</summary>
     public readonly Column<string> vc_pwhash = Column<string>.Text(size: 2048);
+    /// <summary>Security identifier.</summary>
     public readonly Column<string?> vb_sid = Column<string?>.Text(size: 85, nullable: true);
+    /// <summary>Failed login attempt count.</summary>
     public readonly Column<int> i_badlogonattempts = new(value: 0);
+    /// <summary>Indicates whether the user is disabled.</summary>
     public readonly Column<bool> bt_disabled = new();
+    /// <summary>Lockout expiration time.</summary>
     public readonly Column<DateTime?> dt_locked = new();
+    /// <summary>Timestamp of the last successful login.</summary>
     public readonly Column<DateTime?> dt_last_login = new();
+    /// <summary>Timestamp of the last refresh token.</summary>
     public readonly Column<DateTime?> dt_last_refresh = new();
 
+    /// <summary>Recovery code for password reset.</summary>
     public readonly Column<string?> vc_recovery_code = Column<string?>.Text(nullable: true);
+    /// <summary>Time when recovery code was last generated.</summary>
     public readonly Column<DateTime?> dt_last_recovery = new(nullable: true);
 
+    /// <summary>User type identifier.</summary>
     public readonly Column<string> c_usertype_id = Column<string>.EmbedCategory(nameof(UserTypes));
 
+    /// <summary>User group memberships.</summary>
     public readonly Column<string[]?> vc_user_groups = Column<string[]?>.Text(size: 0, nullable: true, isArray: true, fake: true);
 
+    /// <summary>Indicates whether the user is locked.</summary>
     public readonly Column<bool> bt_islocked = new(column_flags: ColumnFlags.None, fake: true);
+    /// <summary>Minutes remaining until unlock.</summary>
     public readonly Column<int> i_locked_minutes_remaining = new(fake: true, column_flags: ColumnFlags.None);
 
+    /// <summary>Plain text password used during creation.</summary>
     public readonly Column<string> vc_password = Column<string>.Text(column_flags: ColumnFlags.None, fake: true);
 
+    /// <summary>Default browse view definition.</summary>
     public readonly ViewDefinition usr_brwStandard = new(nameof(c_user_id));
 
+    /// <summary>Procedure to get user data.</summary>
     public ProcedureDefinition usr_getUserData { get; private set; } = null!;
 
+    /// <summary>Procedure to update login attempt data.</summary>
     public ProcedureDefinition usr_updateLoginAttempt { get; private set; } = null!;
 
+    /// <summary>Procedure to log off a user.</summary>
     public readonly ProcedureDefinition usr_logoff = new(nameof(vc_username));
+    /// <summary>Procedure to set a user password.</summary>
     public readonly ProcedureDefinition usr_setPassword = new(nameof(vc_username), nameof(vc_pwhash));
+    /// <summary>Procedure to reset a user password.</summary>
     public readonly ProcedureDefinition usr_resetPassword = new(nameof(vc_username));
 
+    /// <summary>Procedure to retrieve client claims.</summary>
     public readonly ProcedureDefinition usr_GetClientClaims = new(readonly_locks: true, nameof(vc_username));
+    /// <summary>Procedure to retrieve server claims.</summary>
     public readonly ProcedureDefinition usr_GetServerClaims = new(readonly_locks: true, nameof(vc_username));
+    /// <summary>Procedure to retrieve enabled menus.</summary>
     public readonly ProcedureDefinition usr_GetEnabledMenus = new(readonly_locks: true, nameof(vc_username));
 
+    /// <summary>Procedure to generate a recovery code.</summary>
     public readonly ProcedureDefinition usr_GetRecoveryCode = new(nameof(vc_username));
+    /// <summary>Procedure to get recovery email addresses.</summary>
     public readonly ProcedureDefinition usr_GetRecoveryEmails = new(nameof(vc_username));
+    /// <summary>Procedure to recover a password.</summary>
     public readonly ProcedureDefinition usr_RecoverPassword = new(nameof(vc_username), nameof(vc_recovery_code), nameof(vc_pwhash));
 
     protected override void DefineProcs()
@@ -80,16 +114,38 @@ public class MicromUsersDef : EntityDefinition
 
     }
 
+    /// <summary>
+    /// Unique constraint ensuring usernames are unique.
+    /// </summary>
     public readonly EntityUniqueConstraint UNUsername = new(keys: nameof(vc_username));
 
+    /// <summary>
+    /// Relationship to the groups associated with the user.
+    /// </summary>
     public readonly EntityForeignKey<MicromUsersGroups, MicromUsers> FKGroups = new(fake: true);
 }
 
+/// <summary>
+/// Entity for interacting with MicroM user records.
+/// </summary>
 public class MicromUsers : Entity<MicromUsersDef>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MicromUsers"/> class.
+    /// </summary>
     public MicromUsers() : base() { }
+
+    /// <summary>
+    /// Initializes a new instance with a database client and optional encryptor.
+    /// </summary>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="encryptor">Optional encryptor.</param>
     public MicromUsers(IEntityClient ec, IMicroMEncryption? encryptor = null) : base(ec, encryptor) { }
 
+    /// <summary>
+    /// Inserts the user data hashing the password before saving.
+    /// </summary>
+    /// <inheritdoc/>
     public override Task<DBStatusResult> InsertData(CancellationToken ct, bool throw_dbstat_exception = false, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null)
     {
         var user_login = new UserLogin
@@ -103,6 +159,13 @@ public class MicromUsers : Entity<MicromUsersDef>
         return base.InsertData(ct, throw_dbstat_exception, options, server_claims, api);
     }
 
+    /// <summary>
+    /// Logs off the specified user.
+    /// </summary>
+    /// <param name="username">Username to log off.</param>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Database status result.</returns>
     public async static Task<DBStatusResult> Logoff(string username, IEntityClient ec, CancellationToken ct)
     {
         MicromUsers user = new(ec);
@@ -112,6 +175,15 @@ public class MicromUsers : Entity<MicromUsersDef>
         return await user.Data.ExecuteProcDBStatus(ct, proc);
     }
 
+    /// <summary>
+    /// Retrieves user data for the given identifiers.
+    /// </summary>
+    /// <param name="username">Optional username.</param>
+    /// <param name="user_id">Optional user identifier.</param>
+    /// <param name="device_id">Device identifier.</param>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>User login data if found.</returns>
     public async static Task<LoginData?> GetUserData(string? username, string? user_id, string device_id, IEntityClient ec, CancellationToken ct)
     {
         MicromUsers user = new(ec);
@@ -153,6 +225,13 @@ public class MicromUsers : Entity<MicromUsersDef>
         return [];
     }
 
+    /// <summary>
+    /// Retrieves both server and client claims for a user.
+    /// </summary>
+    /// <param name="username">Username whose claims will be retrieved.</param>
+    /// <param name="ec">Entity client.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Tuple with server and client claims.</returns>
     public async static Task<(Dictionary<string, object> server_claims, Dictionary<string, string> client_claims)> GetClaims(string username, IEntityClient ec, CancellationToken ct)
     {
         Dictionary<string, object> server_claims = [];
@@ -178,6 +257,9 @@ public class MicromUsers : Entity<MicromUsersDef>
     }
 
 
+    /// <summary>
+    /// Updates login attempt information and returns the result.
+    /// </summary>
     public async static Task<LoginAttemptResult> UpdateLoginAttempt(string user_id, string device_id, string? new_refresh_token, bool success, int account_lockout_mins, int refresh_expiration_hours, int max_bad_logon_attempts, string ipaddress, string user_agent, IEntityClient ec, CancellationToken ct)
     {
         MicromUsers user = new(ec);
@@ -206,6 +288,9 @@ public class MicromUsers : Entity<MicromUsersDef>
         return result;
     }
 
+    /// <summary>
+    /// Refreshes a user's token and returns the new token information.
+    /// </summary>
     public async static Task<RefreshTokenResult?> RefreshToken(string user_id, string device_id, string refreshtoken, string new_refresh_token, int refresh_expiration_hours, int max_refresh_count, IEntityClient ec, CancellationToken ct)
     {
         MicromUsersDevices user = new(ec);
@@ -222,6 +307,9 @@ public class MicromUsers : Entity<MicromUsersDef>
         return result;
     }
 
+    /// <summary>
+    /// Obtains a recovery code for the specified user.
+    /// </summary>
     public async static Task<(string? recovery_code, string? error)> GetRecoveryCode(string username, IEntityClient ec, CancellationToken ct)
     {
         MicromUsers user = new(ec);
@@ -240,6 +328,9 @@ public class MicromUsers : Entity<MicromUsersDef>
         return (recovery_code, null);
     }
 
+    /// <summary>
+    /// Retrieves recovery email addresses for the user.
+    /// </summary>
     public async static Task<List<string>> GetRecoveryEmails(string username, IEntityClient ec, CancellationToken ct)
     {
         MicromUsers user = new(ec);
@@ -256,6 +347,9 @@ public class MicromUsers : Entity<MicromUsersDef>
         return result[0].ToListOfStringColumn(header_index.Value);
     }
 
+    /// <summary>
+    /// Recovers a user's password using a recovery code.
+    /// </summary>
     public async static Task<DBStatusResult> RecoverPassword(string username, string recovery_code, string new_password, IEntityClient ec, CancellationToken ct)
     {
         MicromUsers user = new(ec);
@@ -269,6 +363,9 @@ public class MicromUsers : Entity<MicromUsersDef>
     }
 
 
+    /// <summary>
+    /// Sets a new password hash for the user.
+    /// </summary>
     public async static Task<DBStatusResult> usr_setPassword(string username, string pwhash, IEntityClient ec, CancellationToken ct)
     {
 
@@ -281,6 +378,9 @@ public class MicromUsers : Entity<MicromUsersDef>
         return await user.Data.ExecuteProcDBStatus(ct, proc);
     }
 
+    /// <summary>
+    /// Resets a user's password to a random value.
+    /// </summary>
     public async static Task<DBStatusResult> usr_resetPassword(string username, IEntityClient ec, CancellationToken ct)
     {
 

--- a/MicroM/core/DataDictionary/Entities/MicromUsers/MicromUsersDevices.cs
+++ b/MicroM/core/DataDictionary/Entities/MicromUsers/MicromUsersDevices.cs
@@ -5,22 +5,38 @@ using System.Data;
 
 namespace MicroM.DataDictionary
 {
+    /// <summary>
+    /// Schema definition for devices associated with MicroM users.
+    /// </summary>
     public class MicromUsersDevicesDef : EntityDefinition
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MicromUsersDevicesDef"/> class.
+        /// </summary>
         public MicromUsersDevicesDef() : base("usd", nameof(MicromUsersDevices)) { SQLCreationOptions = SQLCreationOptionsMetadata.WithIUpdate; }
 
+        /// <summary>User identifier.</summary>
         public readonly Column<string> c_user_id = Column<string>.PK();
+        /// <summary>Device identifier.</summary>
         public readonly Column<string> c_device_id = Column<string>.PK(sql_type: SqlDbType.VarChar, size: 255);
+        /// <summary>User agent string reported by the device.</summary>
         public readonly Column<string?> vc_useragent = new(sql_type: SqlDbType.VarChar, size: 4096, nullable: true);
+        /// <summary>IP address of the device.</summary>
         public readonly Column<string?> vc_ipaddress = new(sql_type: SqlDbType.VarChar, size: 40, nullable: true);
+        /// <summary>Refresh token assigned to the device.</summary>
         public readonly Column<string?> vc_refreshtoken = new(sql_type: SqlDbType.VarChar, size: 255, nullable: true);
+        /// <summary>Expiration time of the refresh token.</summary>
         public readonly Column<DateTime?> dt_refresh_expiration = new(nullable: true);
+        /// <summary>Number of times the token has been refreshed.</summary>
         public readonly Column<int> i_refreshcount = new(value: 0);
 
+        /// <summary>Default browse view definition.</summary>
         public ViewDefinition usd_brwStandard { get; private set; } = new(nameof(c_user_id), nameof(c_device_id));
 
+        /// <summary>Relationship to the owning user.</summary>
         public readonly EntityForeignKey<MicromUsers, MicromUsersDevices> FKMicromUsers = new();
 
+        /// <summary>Procedure to refresh a device token.</summary>
         public ProcedureDefinition usd_refreshToken { get; private set; } = null!;
 
         protected override void DefineProcs()
@@ -39,9 +55,20 @@ namespace MicroM.DataDictionary
         }
     }
 
+    /// <summary>
+    /// Entity for managing device records linked to users.
+    /// </summary>
     public class MicromUsersDevices : Entity<MicromUsersDevicesDef>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MicromUsersDevices"/> class.
+        /// </summary>
         public MicromUsersDevices() : base() { }
+        /// <summary>
+        /// Initializes a new instance with a database client and optional encryptor.
+        /// </summary>
+        /// <param name="ec">Entity client.</param>
+        /// <param name="encryptor">Optional encryptor.</param>
         public MicromUsersDevices(IEntityClient ec, IMicroMEncryption? encryptor = null) : base(ec, encryptor) { }
     }
 }

--- a/MicroM/core/DataDictionary/Entities/ViewParms/ViewParms.cs
+++ b/MicroM/core/DataDictionary/Entities/ViewParms/ViewParms.cs
@@ -5,30 +5,88 @@ using System.Data;
 
 namespace MicroM.DataDictionary
 {
+    /// <summary>
+    /// Definition for view parameters associated with stored procedures.
+    /// </summary>
     public class ViewParmsDef : EntityDefinition
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ViewParmsDef"/> class.
+        /// </summary>
         public ViewParmsDef() : base("vip", nameof(ViewParms)) { }
 
+        /// <summary>
+        /// Identifier of the object that owns the view.
+        /// </summary>
         public readonly Column<string> c_object_id = Column<string>.PK();
+
+        /// <summary>
+        /// Identifier of the procedure.
+        /// </summary>
         public readonly Column<int> c_proc_id = Column<int>.PK();
+
+        /// <summary>
+        /// Primary key for the view parameter.
+        /// </summary>
         public readonly Column<int> c_viewparm_id = Column<int>.PK(autonum: true);
+
+        /// <summary>
+        /// Name of the parameter.
+        /// </summary>
         public readonly Column<string> vc_parmname = new(sql_type: SqlDbType.VarChar, size: 255);
+
+        /// <summary>
+        /// Column mapping identifier.
+        /// </summary>
         public readonly Column<int?> i_columnmapping = new();
+
+        /// <summary>
+        /// Compound group name.
+        /// </summary>
         public readonly Column<string?> vc_compoundgroup = new(sql_type: SqlDbType.VarChar, size: 80, nullable: true);
+
+        /// <summary>
+        /// Position within the compound group.
+        /// </summary>
         public readonly Column<int?> i_compoundposition = new();
+
+        /// <summary>
+        /// Indicates whether the parameter is part of a compound key.
+        /// </summary>
         public readonly Column<bool> bt_compoundkey = new();
+
+        /// <summary>
+        /// Indicates whether the parameter is used for browsing.
+        /// </summary>
         public readonly Column<bool> bt_browsingkey = new();
 
+        /// <summary>
+        /// Default browse view for view parameters.
+        /// </summary>
         public ViewDefinition vip_brwStandard { get; private set; } = new(nameof(c_object_id), nameof(c_proc_id), nameof(c_viewparm_id));
 
+        /// <summary>
+        /// Relationship to the related <see cref="Procs"/> record.
+        /// </summary>
         public readonly EntityForeignKey<Procs, ViewParms> FKObjects = new();
 
     }
 
+    /// <summary>
+    /// Entity for working with view parameter records.
+    /// </summary>
     public class ViewParms : Entity<ViewParmsDef>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ViewParms"/> class.
+        /// </summary>
         public ViewParms() : base() { }
 
+        /// <summary>
+        /// Initializes a new instance using the specified client and optional encryptor.
+        /// </summary>
+        /// <param name="ec">Entity client for database access.</param>
+        /// <param name="encryptor">Optional encryptor for sensitive data.</param>
         public ViewParms(IEntityClient ec, IMicroMEncryption? encryptor = null) : base(ec, encryptor) { }
 
     }


### PR DESCRIPTION
## Summary
- Add XML `<summary>` documentation to DataDictionary entities such as ViewParms, ConfigurationDB, MicromUsers, and MicromUsersDevices
- Create class reference pages for configuration database and user management types
- Mark `MicroM.DataDictionary` documentation as complete

## Testing
- `dotnet test` *(fails: `/usr/bin/sh: 2: ... del: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5cda524c83248fa83dd4adbf2610