### PR TITLE
Document remaining DataDictionary entities

### DIFF
--- a/MicroM/Documentation-Progress/Backend/docs-state-backend.md
+++ b/MicroM/Documentation-Progress/Backend/docs-state-backend.md
@@ -31,8 +31,8 @@ This file tracks the current documentation state of the backend (`/MicroM/core`)
 - Notes: Namespace and classes documented.
 
 ### MicroM.DataDictionary.Entities
-- State: Incomplete ⚠️
-- Notes: ConfigurationParameters documented; MicromUsers partially documented (LoginResult, LoginAttemptResult, LoginAttemptStatus, LoginData, RefreshTokenResult); added XML comments for EntitiesAssembliesTypes, ObjectsCategories, Classes, and ConfigurationDB InitialConfigurationResult; remaining entities pending.
+- State: Complete ✅
+- Notes: All entities documented with XML comments and pages.
 
 ### MicroM.DataDictionary.Entities.MicromUsers
 - State: Incomplete ⚠️

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/Classes/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/Classes/index.md
@@ -1,0 +1,15 @@
+﻿# Class: MicroM.DataDictionary.Classes
+## Overview
+Runtime entity representing a class associated with an object.
+
+**Inheritance**
+Entity<ClassesDef> -> Classes
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| Classes() | Initializes a new instance. |
+| Classes(IEntityClient ec, IMicroMEncryption? encryptor = null) | Initializes with a database client and optional encryptor. |
+
+## See Also
+- [ClassesDef](../ClassesDef/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/ClassesDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/ClassesDef/index.md
@@ -1,0 +1,22 @@
+﻿# Class: MicroM.DataDictionary.ClassesDef
+## Overview
+Definition for classes associated with objects.
+
+**Inheritance**
+EntityDefinition -> ClassesDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ClassesDef() | Initializes the classes definition. |
+
+## Fields
+| Field | Type | Description |
+|:------------|:-------------|:-------------|
+| c_object_id | Column<string> | Identifier of the object. |
+| c_class_id | Column<string> | Identifier of the class. |
+| vc_classname | Column<string> | Name of the class. |
+| cla_brwStandard | ViewDefinition | Standard browse view. |
+
+## See Also
+- [Classes](../Classes/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/ConfigurationDB/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/ConfigurationDB/index.md
@@ -1,0 +1,22 @@
+﻿# Class: MicroM.DataDictionary.ConfigurationDB
+## Overview
+Runtime entity for accessing and validating configuration database settings.
+
+**Inheritance**
+Entity<ConfigurationDBDef> -> ConfigurationDB
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ConfigurationDB() | Initializes a new instance. |
+| ConfigurationDB(IEntityClient ec, IMicroMEncryption? encryptor = null) | Initializes with a database client and optional encryptor. |
+
+## Methods
+| Method | Description |
+|:------------|:-------------|
+| GetData(CancellationToken ct, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null) | Retrieves configuration data using the provided options and claims. |
+| UpdateData(CancellationToken ct, bool throw_dbstat_exception = false, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null) | Updates configuration data using the provided options and claims. |
+
+## See Also
+- [ConfigurationDBDef](../ConfigurationDBDef/index.md)
+- [InitialConfigurationResult](../InitialConfigurationResult/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/ConfigurationDBDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/ConfigurationDBDef/index.md
@@ -1,0 +1,37 @@
+﻿# Class: MicroM.DataDictionary.ConfigurationDBDef
+## Overview
+Schema definition for configuration database settings.
+
+**Inheritance**
+EntityDefinition -> ConfigurationDBDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ConfigurationDBDef() | Initializes the configuration database definition. |
+
+## Fields
+| Field | Type | Description |
+|:------------|:-------------|:-------------|
+| c_confgidb_id | Column<string> | Fixed identifier for configuration database records. |
+| vc_configsqlserver | Column<string> | SQL Server host name. |
+| vc_configsqluser | Column<string> | SQL Server user name. |
+| vc_configsqlpassword | Column<string?> | SQL Server password. |
+| vc_configdatabase | Column<string> | Configuration database name. |
+| vc_certificatethumbprint | Column<string> | Certificate thumbprint used for encryption. |
+| vc_certificatepassword | Column<string> | Password for the certificate. |
+| vc_certificatename | Column<string> | File name of the certificate. |
+| b_adminuserhasrights | Column<bool> | Indicates whether the admin user has rights. |
+| b_configdbexists | Column<bool> | Indicates whether the configuration database exists. |
+| b_configuserexists | Column<bool> | Indicates whether the configuration user exists. |
+| b_secretsconfigured | Column<bool> | Indicates whether secrets have been configured. |
+| b_defaultcertificate | Column<bool> | Indicates whether a default certificate is being used. |
+| b_thumbprintconfigured | Column<bool> | Indicates whether a thumbprint is configured. |
+| b_thumbprintfound | Column<bool> | Indicates whether the configured thumbprint is found. |
+| b_certificatefound | Column<bool> | Indicates whether the certificate file is found. |
+| b_secretsfilevalid | Column<bool> | Indicates whether the secrets file is valid. |
+| b_recreatedatabase | Column<bool> | Indicates whether the database should be recreated. |
+| dfg_brwStandard | ViewDefinition | Standard browse view. |
+
+## See Also
+- [ConfigurationDB](../ConfigurationDB/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/EntitiesAssembliesTypes/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/EntitiesAssembliesTypes/index.md
@@ -1,0 +1,15 @@
+﻿# Class: MicroM.DataDictionary.EntitiesAssembliesTypes
+## Overview
+Runtime entity for mapping assemblies to their types.
+
+**Inheritance**
+Entity<EntitiesAssembliesTypesDef> -> EntitiesAssembliesTypes
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| EntitiesAssembliesTypes() | Initializes a new instance. |
+| EntitiesAssembliesTypes(IEntityClient ec, IMicroMEncryption? encryptor = null) | Initializes with a database client and optional encryptor. |
+
+## See Also
+- [EntitiesAssembliesTypesDef](../EntitiesAssembliesTypesDef/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/EntitiesAssembliesTypesDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/EntitiesAssembliesTypesDef/index.md
@@ -1,0 +1,23 @@
+﻿# Class: MicroM.DataDictionary.EntitiesAssembliesTypesDef
+## Overview
+Definition for assembly type mappings.
+
+**Inheritance**
+EntityDefinition -> EntitiesAssembliesTypesDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| EntitiesAssembliesTypesDef() | Initializes the assembly types definition. |
+
+## Fields
+| Field | Type | Description |
+|:------------|:-------------|:-------------|
+| c_assembly_id | Column<string> | Identifier of the assembly. |
+| c_assemblytype_id | Column<string> | Identifier of the assembly type. |
+| vc_assemblytypename | Column<string> | Name of the assembly type. |
+| eat_brwStandard | ViewDefinition | Standard browse view. |
+| eat_deleteAllTypes | ProcedureDefinition | Procedure that removes all types. |
+
+## See Also
+- [EntitiesAssembliesTypes](../EntitiesAssembliesTypes/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/InitialConfigurationResult/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/InitialConfigurationResult/index.md
@@ -1,0 +1,30 @@
+﻿# Class: MicroM.DataDictionary.InitialConfigurationResult
+## Overview
+Represents the result of the initial configuration validation process.
+
+**Inheritance**
+EntityActionResult -> InitialConfigurationResult
+
+## Example Usage
+```csharp
+var result = new MicroM.DataDictionary.InitialConfigurationResult();
+```
+## Properties
+| Property | Type | Description |
+|:------------|:-------------|:-------------|
+| ConfigDBValid | bool | Indicates whether the configuration database values are valid. |
+| ConfigUserameValid | bool | Indicates whether the configuration username is valid. |
+| ConfigPasswordValid | bool | Indicates whether the configuration password is valid. |
+| ConfigDBExists | bool | Indicates whether the configuration database exists. |
+| ConfigUserExists | bool | Indicates whether the configuration user exists. |
+| AdminUserHasRights | bool | Indicates whether the administrator user has rights. |
+| CertificateThumbprint | string? | Certificate thumbprint used for encryption. |
+| CertificatePath | string? | Path to the certificate file. |
+| CertificatePassword | string? | Password for the certificate. |
+| ConfigSQLServer | string? | SQL Server instance configured for the application. |
+| ConfigSQLServerDB | string? | Configuration database name. |
+| ConfigSQLUser | string? | SQL user name for configuration. |
+| ConfigSQLPassword | string? | SQL password for configuration. |
+
+## See Also
+- [ConfigurationDB](../ConfigurationDB/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/ObjectsCategories/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/ObjectsCategories/index.md
@@ -1,0 +1,15 @@
+﻿# Class: MicroM.DataDictionary.ObjectsCategories
+## Overview
+Runtime entity for associating objects with categories.
+
+**Inheritance**
+Entity<ObjectsCategoriesDef> -> ObjectsCategories
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ObjectsCategories() | Initializes a new instance. |
+| ObjectsCategories(IEntityClient ec, IMicroMEncryption? encryptor = null) | Initializes with a database client and optional encryptor. |
+
+## See Also
+- [ObjectsCategoriesDef](../ObjectsCategoriesDef/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/ObjectsCategoriesDef/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/ObjectsCategoriesDef/index.md
@@ -1,0 +1,21 @@
+﻿# Class: MicroM.DataDictionary.ObjectsCategoriesDef
+## Overview
+Definition linking objects to categories.
+
+**Inheritance**
+EntityDefinition -> ObjectsCategoriesDef
+
+## Constructors
+| Constructor | Description |
+|:------------|:-------------|
+| ObjectsCategoriesDef() | Initializes the object categories definition. |
+
+## Fields
+| Field | Type | Description |
+|:------------|:-------------|:-------------|
+| c_object_id | Column<string> | Identifier of the object. |
+| c_category_id | Column<string> | Identifier of the category. |
+| oca_brwStandard | ViewDefinition | Standard browse view. |
+
+## See Also
+- [ObjectsCategories](../ObjectsCategories/index.md)

--- a/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/index.md
+++ b/MicroM/Documentation/Backend/MicroM.DataDictionary.Entities/index.md
@@ -1,12 +1,21 @@
 # Namespace: MicroM.DataDictionary.Entities
 ## Overview
-Contains entity definitions used by the MicroM data dictionary such as configuration parameters and application URLs.
+Contains entity definitions used by the MicroM data dictionary such as configuration parameters and application mappings.
 
 ## Classes
 | Class | Description |
 |:------------|:-------------|
-| [ConfigurationParametersDef](<ConfigurationParametersDef/index.md>) | Schema definition for configuration parameters. |
+| [Classes](<Classes/index.md>) | Runtime entity representing a class associated with an object. |
+| [ClassesDef](<ClassesDef/index.md>) | Definition for classes associated with objects. |
+| [ConfigurationDB](<ConfigurationDB/index.md>) | Runtime entity for configuration database settings. |
+| [ConfigurationDBDef](<ConfigurationDBDef/index.md>) | Schema definition for configuration database settings. |
 | [ConfigurationParameters](<ConfigurationParameters/index.md>) | Entity for storing configuration parameter values. |
+| [ConfigurationParametersDef](<ConfigurationParametersDef/index.md>) | Schema definition for configuration parameters. |
+| [EntitiesAssembliesTypes](<EntitiesAssembliesTypes/index.md>) | Runtime entity for mapping assemblies to their types. |
+| [EntitiesAssembliesTypesDef](<EntitiesAssembliesTypesDef/index.md>) | Definition for assembly type mappings. |
+| [InitialConfigurationResult](<InitialConfigurationResult/index.md>) | Result of initial configuration validation. |
+| [ObjectsCategories](<ObjectsCategories/index.md>) | Runtime entity for associating objects with categories. |
+| [ObjectsCategoriesDef](<ObjectsCategoriesDef/index.md>) | Definition linking objects to categories. |
 
 ## Enums
 | Enum | Description |
@@ -21,7 +30,7 @@ Contains entity definitions used by the MicroM data dictionary such as configura
 |:------------|:-------------|
 
 ## Remarks
-Additional entities exist in this namespace and will be documented in future iterations.
+None.
 
 ## See Also
 - [MicroM.DataDictionary](../MicroM.DataDictionary/index.md)

--- a/MicroM/core/DataDictionary/Entities/Classes/Classes.cs
+++ b/MicroM/core/DataDictionary/Entities/Classes/Classes.cs
@@ -66,6 +66,8 @@ namespace MicroM.DataDictionary
         /// <summary>
         /// Initializes a new instance using the specified entity client and optional encryptor.
         /// </summary>
+        /// <param name="ec">Entity client used for data access.</param>
+        /// <param name="encryptor">Optional encryptor for sensitive fields.</param>
         public Classes(IEntityClient ec, IMicroMEncryption? encryptor = null) : base(ec, encryptor) { }
 
     }

--- a/MicroM/core/DataDictionary/Entities/ConfigurationDB/ConfigurationDB.cs
+++ b/MicroM/core/DataDictionary/Entities/ConfigurationDB/ConfigurationDB.cs
@@ -8,43 +8,126 @@ using static System.ArgumentNullException;
 
 namespace MicroM.DataDictionary;
 
+/// <summary>
+/// Schema definition for configuration database settings.
+/// </summary>
 public class ConfigurationDBDef : EntityDefinition
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationDBDef"/> class.
+    /// </summary>
     public ConfigurationDBDef() : base("dfg", nameof(ConfigurationDB)) { Fake = true; }
 
+    /// <summary>
+    /// Fixed identifier for configuration database records.
+    /// </summary>
     public readonly Column<string> c_confgidb_id = Column<string>.PK(value: "1");
 
+    /// <summary>
+    /// SQL Server host name.
+    /// </summary>
     public readonly Column<string> vc_configsqlserver = new(sql_type: SqlDbType.VarChar, size: 255);
+    /// <summary>
+    /// SQL Server user name.
+    /// </summary>
     public readonly Column<string> vc_configsqluser = new(sql_type: SqlDbType.VarChar, size: 255);
+    /// <summary>
+    /// SQL Server password.
+    /// </summary>
     public readonly Column<string?> vc_configsqlpassword = new(sql_type: SqlDbType.VarChar, size: 2048, nullable: true);
+    /// <summary>
+    /// Configuration database name.
+    /// </summary>
     public readonly Column<string> vc_configdatabase = new(sql_type: SqlDbType.VarChar, size: 255);
 
+    /// <summary>
+    /// Certificate thumbprint used for encryption.
+    /// </summary>
     public readonly Column<string> vc_certificatethumbprint = new(sql_type: SqlDbType.VarChar, size: 255);
+    /// <summary>
+    /// Password for the certificate.
+    /// </summary>
     public readonly Column<string> vc_certificatepassword = new(sql_type: SqlDbType.VarChar, size: 2048);
+    /// <summary>
+    /// File name of the certificate.
+    /// </summary>
     public readonly Column<string> vc_certificatename = new(sql_type: SqlDbType.VarChar, size: 2048);
 
+    /// <summary>
+    /// Indicates whether the admin user has rights.
+    /// </summary>
     public readonly Column<bool> b_adminuserhasrights = new(sql_type: SqlDbType.Bit);
+    /// <summary>
+    /// Indicates whether the configuration database exists.
+    /// </summary>
     public readonly Column<bool> b_configdbexists = new(sql_type: SqlDbType.Bit);
+    /// <summary>
+    /// Indicates whether the configuration user exists.
+    /// </summary>
     public readonly Column<bool> b_configuserexists = new(sql_type: SqlDbType.Bit);
+    /// <summary>
+    /// Indicates whether secrets have been configured.
+    /// </summary>
     public readonly Column<bool> b_secretsconfigured = new(sql_type: SqlDbType.Bit);
+    /// <summary>
+    /// Indicates whether a default certificate is being used.
+    /// </summary>
     public readonly Column<bool> b_defaultcertificate = new(sql_type: SqlDbType.Bit);
+    /// <summary>
+    /// Indicates whether a thumbprint is configured.
+    /// </summary>
     public readonly Column<bool> b_thumbprintconfigured = new(sql_type: SqlDbType.Bit);
+    /// <summary>
+    /// Indicates whether the configured thumbprint is found.
+    /// </summary>
     public readonly Column<bool> b_thumbprintfound = new(sql_type: SqlDbType.Bit);
+    /// <summary>
+    /// Indicates whether the certificate file is found.
+    /// </summary>
     public readonly Column<bool> b_certificatefound = new(sql_type: SqlDbType.Bit);
+    /// <summary>
+    /// Indicates whether the secrets file is valid.
+    /// </summary>
     public readonly Column<bool> b_secretsfilevalid = new(sql_type: SqlDbType.Bit);
 
+    /// <summary>
+    /// Indicates whether the database should be recreated.
+    /// </summary>
     public readonly Column<bool> b_recreatedatabase = new(sql_type: SqlDbType.Bit);
 
+    /// <summary>
+    /// Standard browse view for configuration database records.
+    /// </summary>
     public ViewDefinition dfg_brwStandard { get; private set; } = new(nameof(c_confgidb_id));
 
 }
 
+/// <summary>
+/// Runtime entity for accessing and validating configuration database settings.
+/// </summary>
 public class ConfigurationDB : Entity<ConfigurationDBDef>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationDB"/> class.
+    /// </summary>
     public ConfigurationDB() : base() { }
+    /// <summary>
+    /// Initializes a new instance using the specified entity client and optional encryptor.
+    /// </summary>
+    /// <param name="ec">Entity client used for data access.</param>
+    /// <param name="encryptor">Optional encryptor for sensitive fields.</param>
     public ConfigurationDB(IEntityClient ec, IMicroMEncryption? encryptor = null) : base(ec, encryptor) { }
 
 
+    /// <summary>
+    /// Retrieves configuration data using the provided options and claims.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="options">Framework configuration options.</param>
+    /// <param name="server_claims">Server claims containing connection information.</param>
+    /// <param name="api">Optional Web API services instance.</param>
+    /// <param name="app_id">Optional application identifier.</param>
+    /// <returns>True if data retrieval succeeded; otherwise, false.</returns>
     public override async Task<bool> GetData(CancellationToken ct, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null)
     {
         ThrowIfNull(server_claims);
@@ -52,6 +135,16 @@ public class ConfigurationDB : Entity<ConfigurationDBDef>
         return await HandleGetData(this, options, server_claims, ct);
     }
 
+    /// <summary>
+    /// Updates configuration data using the provided options and claims.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="throw_dbstat_exception">Whether to throw if the database status indicates an error.</param>
+    /// <param name="options">Framework configuration options.</param>
+    /// <param name="server_claims">Server claims containing connection information.</param>
+    /// <param name="api">Optional Web API services instance.</param>
+    /// <param name="app_id">Optional application identifier.</param>
+    /// <returns>Result of the database operation.</returns>
     public override async Task<DBStatusResult> UpdateData(CancellationToken ct, bool throw_dbstat_exception = false, MicroMOptions? options = null, Dictionary<string, object>? server_claims = null, IWebAPIServices? api = null, string? app_id = null)
     {
         ThrowIfNull(server_claims);

--- a/MicroM/core/DataDictionary/Entities/EntitiesAssembliesTypes/EntitiesAssembliesTypes.cs
+++ b/MicroM/core/DataDictionary/Entities/EntitiesAssembliesTypes/EntitiesAssembliesTypes.cs
@@ -62,6 +62,8 @@ namespace MicroM.DataDictionary
         /// <summary>
         /// Initializes a new instance using the specified entity client and optional encryptor.
         /// </summary>
+        /// <param name="ec">Entity client used for data access.</param>
+        /// <param name="encryptor">Optional encryptor for sensitive fields.</param>
         public EntitiesAssembliesTypes(IEntityClient ec, IMicroMEncryption? encryptor = null) : base(ec, encryptor) { }
 
     }

--- a/MicroM/core/DataDictionary/Entities/ObjectsCategories/ObjectsCategories.cs
+++ b/MicroM/core/DataDictionary/Entities/ObjectsCategories/ObjectsCategories.cs
@@ -51,6 +51,8 @@ public class ObjectsCategories : Entity<ObjectsCategoriesDef>
     /// <summary>
     /// Initializes a new instance using the specified entity client and optional encryptor.
     /// </summary>
+    /// <param name="ec">Entity client used for data access.</param>
+    /// <param name="encryptor">Optional encryptor for sensitive fields.</param>
     public ObjectsCategories(IEntityClient ec, IMicroMEncryption? encryptor = null) : base(ec, encryptor) { }
 
 }


### PR DESCRIPTION
## Summary
- add XML documentation for ConfigurationDB and constructors for entity classes
- document EntitiesAssembliesTypes, ObjectsCategories, Classes, ConfigurationDB, and InitialConfigurationResult
- mark `MicroM.DataDictionary.Entities` documentation as complete

## Testing
- `dotnet test` *(fails: NuGet.Config is not valid XML)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5cdd922883249d67324430e4c2b7